### PR TITLE
Added shebang to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from setuptools import setup, find_packages
  
 setup(name='django-payments',


### PR DESCRIPTION
I believe this is fairly standard in setup.py files. I tried cloning the repo and doing this:

```
sudo ./setup.py install
```

Which threw an error until I added the shebang line.
