### PR TITLE
filter() doesn't return a list in Python 3

### DIFF
--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -5,6 +5,11 @@ import json
 import requests
 from decimal import Decimal, ROUND_HALF_UP
 
+try:
+    from itertools import ifilter as filter
+except ImportError:
+    pass
+
 from django.http import HttpResponseForbidden
 from django.shortcuts import redirect
 from django.utils import timezone


### PR DESCRIPTION
In Python 3 filter() returns a iterable filter object, next() returns the first item, without this patch the Paypal backend causes this error: TypeError: 'filter' object is not subscriptable
