### PR TITLE
Disallow to send empty payment description

### DIFF
--- a/payments/dotpay/__init__.py
+++ b/payments/dotpay/__init__.py
@@ -33,6 +33,9 @@ class DotpayProvider(BasicProvider):
         super(DotpayProvider, self).__init__(*args, **kwargs)
 
     def get_hidden_fields(self):
+        if not self.payment.description:
+            raise ValueError('Payment description is required')
+
         data = {
             'id': self._seller_id,
             'amount': str(self.payment.total),


### PR DESCRIPTION
`DotPay` requires not empty payment description.
