### PR TITLE
Simplify dummy providers

### DIFF
--- a/payments/dummy/__init__.py
+++ b/payments/dummy/__init__.py
@@ -9,7 +9,7 @@ except ImportError:
     from urllib import urlencode
 from django.http import HttpResponseRedirect
 
-from .forms import DummyForm, Dummy3DSecureForm
+from .forms import DummyForm
 from .. import BasicProvider, RedirectNeeded, PaymentError
 
 
@@ -26,15 +26,37 @@ class DummyProvider(BasicProvider):
             self.payment.change_status(new_status)
             new_fraud_status = form.cleaned_data['fraud_status']
             self.payment.change_fraud_status(new_fraud_status)
-            if new_status == 'confirmed':
+
+            gateway_response = form.cleaned_data.get('gateway_response')
+            verification_result = form.cleaned_data.get('verification_result')
+            if gateway_response or verification_result:
+                if gateway_response == '3ds-disabled':
+                    # Standard request without 3DSecure
+                    pass
+                elif gateway_response == '3ds-redirect':
+                    # Simulate redirect to 3DS and get back to normal
+                    # payment processing
+                    process_url = self.payment.get_process_url()
+                    params = urlencode(
+                        {'verification_result': verification_result})
+                    redirect_url = '%s?%s' % (process_url, params)
+                    raise RedirectNeeded(redirect_url)
+                elif gateway_response == 'failure':
+                    # Gateway raises error (HTTP 500 for example)
+                    raise URLError('Opps')
+                elif gateway_response == 'payment-error':
+                    raise PaymentError('Unsupported operation')
+
+            if new_status in ['preauth', 'confirmed']:
                 raise RedirectNeeded(self.payment.get_success_url())
             raise RedirectNeeded(self.payment.get_failure_url())
-        else:
-            self.payment.change_status('input')
         return form
 
     def process_data(self, request):
-        if self.payment.status == 'confirmed':
+        verification_result = request.GET.get('verification_result')
+        if verification_result:
+            self.payment.change_status(verification_result)
+        if self.payment.status in ['confirmed', 'preauth']:
             return HttpResponseRedirect(self.payment.get_success_url())
         return HttpResponseRedirect(self.payment.get_failure_url())
 
@@ -47,50 +69,3 @@ class DummyProvider(BasicProvider):
 
     def refund(self, amount=None):
         return amount or 0
-
-
-class Dummy3DSecureProvider(DummyProvider):
-    '''
-    Dummy provider with 3D-Secure support
-    '''
-
-    def get_form(self, data=None):
-        form = Dummy3DSecureForm(data=data, hidden_inputs=False, provider=self,
-                                 payment=self.payment)
-        if form.is_valid():
-            new_status = form.cleaned_data['status']
-            self.payment.change_status(new_status)
-            new_fraud_status = form.cleaned_data['fraud_status']
-            self.payment.change_fraud_status(new_fraud_status)
-            gateway_respose = form.cleaned_data['gateway_response']
-            verification_result = form.cleaned_data['verification_result']
-            if gateway_respose == '3ds-disabled':
-                # Standard request without 3DSecure
-                pass
-            elif gateway_respose == '3ds-redirect':
-                # Simulate redirect to 3DS and get back to normal
-                # payment processing
-                process_url = self.payment.get_process_url()
-                params = urlencode(
-                    {'verification_result': verification_result})
-                redirect_url = '%s?%s' % (process_url, params)
-                raise RedirectNeeded(redirect_url)
-            elif gateway_respose == 'failure':
-                # Gateway raises error (HTTP 500 for example)
-                raise URLError('Opps')
-            elif gateway_respose == 'payment-error':
-                raise PaymentError('Unsupported operation')
-
-            if new_status == 'preauth':
-                raise RedirectNeeded(self.payment.get_success_url())
-            raise RedirectNeeded(self.payment.get_failure_url())
-
-        return form
-
-    def process_data(self, request):
-        verification_result = request.GET.get('verification_result')
-        if verification_result:
-            self.payment.change_status(verification_result)
-        if self.payment.status in ['confirmed', 'preauth']:
-            return HttpResponseRedirect(self.payment.get_success_url())
-        return HttpResponseRedirect(self.payment.get_failure_url())

--- a/payments/dummy/forms.py
+++ b/payments/dummy/forms.py
@@ -7,11 +7,6 @@ from ..models import PAYMENT_STATUS_CHOICES, FRAUD_CHOICES
 
 class DummyForm(PaymentForm):
 
-    status = forms.ChoiceField(choices=PAYMENT_STATUS_CHOICES)
-    fraud_status = forms.ChoiceField(choices=FRAUD_CHOICES)
-
-
-class Dummy3DSecureForm(PaymentForm):
     RESPONSE_CHOICES = (
         ('3ds-disabled', '3DS disabled'),
         ('3ds-redirect', '3DS redirect'),
@@ -25,7 +20,7 @@ class Dummy3DSecureForm(PaymentForm):
                                             required=False)
 
     def clean(self):
-        cleaned_data = super(Dummy3DSecureForm, self).clean()
+        cleaned_data = super(DummyForm, self).clean()
         gateway_response = cleaned_data['gateway_response']
         verification_result = cleaned_data.get('verification_result')
         if gateway_response == '3ds-redirect' and not verification_result:

--- a/payments/dummy/tests.py
+++ b/payments/dummy/tests.py
@@ -12,7 +12,7 @@ except ImportError:
 
 from payments import RedirectNeeded, PaymentError
 
-from . import Dummy3DSecureProvider
+from . import DummyProvider
 
 
 VARIANT = 'dummy-3ds'
@@ -49,7 +49,7 @@ class TestDummy3DSProvider(TestCase):
         self.payment = Payment()
 
     def test_process_data_supports_verification_result(self):
-        provider = Dummy3DSecureProvider(self.payment)
+        provider = DummyProvider(self.payment)
         verification_status = 'confirmed'
         request = MagicMock()
         request.GET = {'verification_result': verification_status}
@@ -60,7 +60,7 @@ class TestDummy3DSProvider(TestCase):
 
     def test_process_data_redirects_to_success_on_payment_success(self):
         self.payment.status = 'preauth'
-        provider = Dummy3DSecureProvider(self.payment)
+        provider = DummyProvider(self.payment)
         request = MagicMock()
         request.GET = {}
         response = provider.process_data(request)
@@ -68,14 +68,14 @@ class TestDummy3DSProvider(TestCase):
 
     def test_process_data_redirects_to_failure_on_payment_failure(self):
         self.payment.status = 'reject'
-        provider = Dummy3DSecureProvider(self.payment)
+        provider = DummyProvider(self.payment)
         request = MagicMock()
         request.GET = {}
         response = provider.process_data(request)
         self.assertEqual(response['location'], self.payment.get_failure_url())
 
     def test_provider_supports_non_3ds_transactions(self):
-        provider = Dummy3DSecureProvider(self.payment)
+        provider = DummyProvider(self.payment)
         data = {
             'status': 'preauth',
             'fraud_status': 'unknown',
@@ -87,7 +87,7 @@ class TestDummy3DSProvider(TestCase):
             self.assertEqual(exc.args[0], self.payment.get_success_url())
 
     def test_provider_supports_3ds_redirect(self):
-        provider = Dummy3DSecureProvider(self.payment)
+        provider = DummyProvider(self.payment)
         verification_result = 'confirmed'
         data = {
             'status': 'waiting',
@@ -103,7 +103,7 @@ class TestDummy3DSProvider(TestCase):
             self.assertEqual(exc.args[0], expected_redirect)
 
     def test_provider_supports_gateway_failure(self):
-        provider = Dummy3DSecureProvider(self.payment)
+        provider = DummyProvider(self.payment)
         data = {
             'status': 'waiting',
             'fraud_status': 'unknown',
@@ -114,7 +114,7 @@ class TestDummy3DSProvider(TestCase):
             provider.get_form(data)
 
     def test_provider_raises_redirect_needed_on_success(self):
-        provider = Dummy3DSecureProvider(self.payment)
+        provider = DummyProvider(self.payment)
         data = {
             'status': 'preauth',
             'fraud_status': 'unknown',
@@ -126,7 +126,7 @@ class TestDummy3DSProvider(TestCase):
             self.assertEqual(exc.args[0], self.payment.get_success_url())
 
     def test_provider_raises_redirect_needed_on_failure(self):
-        provider = Dummy3DSecureProvider(self.payment)
+        provider = DummyProvider(self.payment)
         data = {
             'status': 'error',
             'fraud_status': 'unknown',
@@ -138,7 +138,7 @@ class TestDummy3DSProvider(TestCase):
             self.assertEqual(exc.args[0], self.payment.get_failure_url())
 
     def test_provider_raises_payment_error(self):
-        provider = Dummy3DSecureProvider(self.payment)
+        provider = DummyProvider(self.payment)
         data = {
             'status': 'preauth',
             'fraud_status': 'unknown',


### PR DESCRIPTION
Extend DummyProvider instead of creating new class for 3DSecure-enabled provider
