### PR TITLE
Use only required fields in stripe js

### DIFF
--- a/payments/static/js/payments/stripe.js
+++ b/payments/static/js/payments/stripe.js
@@ -11,13 +11,7 @@ document.addEventListener('DOMContentLoaded', function () {
             number: this.elements['number'].value,
             cvc: this.elements['cvv2'].value,
             exp_month: this.elements['expiration_0'].value,
-            exp_year: this.elements['expiration_1'].value,
-            address_line1: stripeInput.attributes['data-address-line1'].value,
-            address_line2: stripeInput.attributes['data-address-line2'].value,
-            address_city: stripeInput.attributes['data-address-city'].value,
-            address_state: stripeInput.attributes['data-address-state'].value,
-            address_zip: stripeInput.attributes['data-address-zip'].value,
-            address_country: stripeInput.attributes['data-address-country'].value
+            exp_year: this.elements['expiration_1'].value
         }, function (status, response) {
             if (400 <= status && status <= 500) {
                 alert(response.error.message);

--- a/payments/stripe/forms.py
+++ b/payments/stripe/forms.py
@@ -85,9 +85,3 @@ class PaymentForm(StripeFormMixin, CreditCardPaymentFormWithName):
         super(PaymentForm, self).__init__(*args, **kwargs)
         stripe_attrs = self.fields['stripeToken'].widget.attrs
         stripe_attrs['data-publishable-key'] = self.provider.public_key
-        stripe_attrs['data-address-line1'] = self.payment.billing_address_1
-        stripe_attrs['data-address-line2'] = self.payment.billing_address_2
-        stripe_attrs['data-address-city'] = self.payment.billing_city
-        stripe_attrs['data-address-state'] = self.payment.billing_country_area
-        stripe_attrs['data-address-zip'] = self.payment.billing_postcode
-        stripe_attrs['data-address-country'] = self.payment.billing_country_code


### PR DESCRIPTION
Stripe doesn't require address, to create card token: https://stripe.com/docs/api#create_card_token
