### PR TITLE
attrs: fix getattr, hasattr on missing attributes

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -19,7 +19,10 @@ class PaymentAttributeProxy(object):
 
     def __getattr__(self, item):
         data = json.loads(self._payment.extra_data or '{}')
-        return data[item]
+        try:
+            return data[item]
+        except KeyError as e:
+            raise AttributeError(*e.args)
 
     def __setattr__(self, key, value):
         if key == '_payment':

--- a/payments/test_core.py
+++ b/payments/test_core.py
@@ -37,6 +37,8 @@ class TestBasePayment(TestCase):
             extra_data='{"attr1": "test1", "attr2": "test2"}')
         self.assertEqual(payment.attrs.attr1, "test1")
         self.assertEqual(payment.attrs.attr2, 'test2')
+        self.assertEqual(getattr(payment.attrs, "attr5", None), None)
+        self.assertEqual(hasattr(payment.attrs, "attr7"), False)
 
     def test_capture_with_wrong_status(self):
         payment = BasePayment(variant='default', status=PaymentStatus.WAITING)


### PR DESCRIPTION
Fix getattr, hasattr calls on missing attributes.
E.g. if the dictionary is not initialized or some attributes are optional.
Add tests for these cases.