### PR TITLE
Pre-fill billing information on PayPal (work in progress)

### DIFF
--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -196,7 +196,9 @@ class PaypalProvider(BasicProvider):
         #
         # See: https://developer.paypal.com/docs/api/payments/v1/#definition-item_list
         billing_address = {
-            "recipient_name": " ".join([payment.billing_first_name, payment.billing_last_name]),
+            "recipient_name": " ".join(
+                [payment.billing_first_name, payment.billing_last_name]
+            ),
             "line1": payment.billing_address_1,
             "line2": payment.billing_address_2,
             "city": payment.billing_city,

--- a/payments/paypal/test_paypal.py
+++ b/payments/paypal/test_paypal.py
@@ -42,6 +42,15 @@ class Payment(Mock):
     variant = VARIANT
     transaction_id = None
     message = ""
+    billing_first_name = "John"
+    billing_last_name = "Doe"
+    billing_address_1 = "Unit 4"
+    billing_address_2 = "5 Green Street"
+    billing_city = "Greenville"
+    billing_postcode = "1234"
+    billing_country_code = "US"
+    billing_country_area = "Some state"
+    billing_email = "john@example.com"
     extra_data = json.dumps(
         {
             "links": {


### PR DESCRIPTION
I've had this patch running in production with Saleor for about a year and thought it might be useful to others. May not yet be suitable to merge.

~~Also handles blank phone number which would otherwise cause a baffling "400 Bad Request" from PayPal.~~ (removed as not available on `BasePayment`.

Related to the possibly abandoned #132.