### PR TITLE
add request parameter to get_base_url to pass it to Site.objects.get_current(request)

### DIFF
--- a/payments/core.py
+++ b/payments/core.py
@@ -36,7 +36,10 @@ def get_base_url(request=None):
             current_site = Site.objects.get_current(request)
             domain = current_site.domain
         except Site.DoesNotExist:
-            domain = request.get_host()
+            if request:
+                domain = request.get_host()
+            else:
+                raise
     elif callable(PAYMENT_HOST):
         domain = PAYMENT_HOST()
     else:


### PR DESCRIPTION
it is default to None so no change needed to existing codes.
also don't fail if Site is not found, useful for setups where the domain is dynamic and don't have one to one relation with django sites framework 