### PR TITLE
allow to set label for provider to be used in templates

### DIFF
--- a/payments/core.py
+++ b/payments/core.py
@@ -51,8 +51,9 @@ class BasicProvider(object):
     def get_action(self, payment):
         return self.get_return_url(payment)
 
-    def __init__(self, capture=True):
+    def __init__(self, capture=True, label=""):
         self._capture = capture
+        self._label = label
 
     def get_hidden_fields(self, payment):
         '''


### PR DESCRIPTION
I added labels for the payment methods to configuration for usage in my template with autogenerated payment method chooser. This code I need to do that.