### PR TITLE
add tax rate to the PurchasedItem

### DIFF
--- a/payments/__init__.py
+++ b/payments/__init__.py
@@ -6,7 +6,9 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import pgettext_lazy
 
 PurchasedItem = namedtuple('PurchasedItem',
-                           'name, quantity, price, currency, sku')
+                           'name, quantity, price, currency, sku, tax_rate')
+PurchasedItem.__new__.__defaults__ = (None, None, None, None, None, 1)
+# In Python 3.7 and higher the defaults could be set as attribute of namedtuple
 
 
 class PaymentStatus:


### PR DESCRIPTION
PayU provider needs to state every item price including tax in contrast with PayPal, that needs the price without tax.
So if the `PurchasedItem.price` is without tax I don't have enough information for PayU implementation.
I think, that it would be best to add tax rate, because some theoretical provider could need tax rate stated for every item (every item could have different rate).