### PR TITLE
Make `status_changed` safer

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -89,7 +89,7 @@ class BasePayment(models.Model):
         from .signals import status_changed
         self.status = status
         self.message = message
-        self.save()
+        self.save(update_fields=["status", "message"])
         status_changed.send(sender=type(self), instance=self)
 
     def change_fraud_status(self, status: PaymentStatus, message='', commit=True):


### PR DESCRIPTION
When a Payment changes status, its `status` and `message` are updated, but the call to `save` can potentially lead to overwrites of other fields due to Django's optimistic locking.

This change explicitly specifies the two fields to update when saving inside this method.