### PR TITLE
Drop pushing to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,6 @@ jobs:
           python setup.py sdist --format=gztar bdist_wheel
           twine check dist/*
 
-      - name: Upload packages to GitHub release
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: svenstaro/upload-release-action@483c1e56f95e88835747b1c7c60581215016cbf2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/*
-          file_glob: true
-          tag: ${{ github.ref }}
-          overwrite: true
-
       - name: Upload packages to Jazzband
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@master

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+# Pin setuptools to an older version, since suds-jarko
+# doesn't build with the latest.
+requires = ["setuptools<58"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,10 @@ setup(
         "version_scheme": "post-release",
         "write_to": "payments/version.py",
     },
-    setup_requires=["setuptools_scm"],
+    setup_requires=[
+        "setuptools_scm",
+        "setuptools<58",
+    ],
     url="http://github.com/jazzband/django-payments",
     packages=PACKAGES,
     include_package_data=True,


### PR DESCRIPTION
Attempting to fix #267

There's little use for these packages anyway, since it's not the type of package people would manually download and install or alike.