### PR TITLE
Replace suds with a fork that still installs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ v0.15.0
   to extra (optional) dependencies. See the installation instructions for
   further details.
 - Added support for MercadoPago.
+- ``suds-jurko`` has been replaced with `suds-community`, since the former
+  no longer installs with recent ``setuptools``.
 
 v0.14.0
 -------

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
     extras_require={
         "braintree": ["braintree>=3.14.0"],
-        "cybersource": ["suds-jurko>=0.6"],
+        "cybersource": ["suds-community>=0.6"],
         "docs": ["sphinx_rtd_theme"],
         "mercadopago": ["mercadopago>=2.0.0,<3.0.0"],
         "sagepay": ["cryptography>=1.1.0"],


### PR DESCRIPTION
See https://github.com/andersinno/suds-jurko/issues/6 and https://github.com/pypa/setuptools/issues/2784.

We'll want to port this to use Zeep in future though, but need better tests to make sure we don't regress.