### PR TITLE
(WIP) PayPal subscribtions

### DIFF
--- a/payments/core.py
+++ b/payments/core.py
@@ -119,6 +119,22 @@ class BasicProvider:
             return url + "?" + qs
         return url
 
+    def autocomplete_with_subscription(self, payment):
+        """
+        Complete the payment with subscription
+        Used by providers, that use server initiated subscription workflow
+
+        Throws RedirectNeeded if there is problem with the payment that needs to be solved by user
+        """
+        raise NotImplementedError()
+
+    def cancel_subscription(self, subscription):
+        """
+        Cancel subscription
+        Used by providers, that use provider initiated subscription workflow
+        """
+        raise NotImplementedError()
+
     def capture(self, payment, amount=None):
         raise NotImplementedError()
 

--- a/payments/models.py
+++ b/payments/models.py
@@ -48,8 +48,8 @@ class BaseSubscription(models.Model):
         blank=True,
     )
     payment_provider = models.CharField(
-        _('payment provider'),
-        help_text=_('Provider variant, that will be used for payment renewal'),
+        _("payment provider"),
+        help_text=_("Provider variant, that will be used for payment renewal"),
         max_length=255,
         default=None,
         null=True,

--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -312,6 +312,22 @@ class PaypalProvider(BasicProvider):
             plan_id = self.plan_id
         plan_data = {
             "plan_id": plan_id,
+            "plan": {  # Override plan values
+                "billing_cycles": [{
+                    "sequence": 1,
+                    # TODO: This doesn't work:
+                    # "frequency": {
+                    #     "interval_unit": payment.get_subscription().get_unit(),
+                    #     "interval_count": payment.get_subscription().get_period(),
+                    # },
+                    "pricing_scheme": {
+                        "fixed_price": {
+                            "currency_code": payment.currency,
+                            "value": str(payment.total.quantize(CENTS, rounding=ROUND_HALF_UP)),
+                        },
+                    },
+                }],
+            },
             "application_context": {
                 "shipping_preference": "NO_SHIPPING",
                 "user_action": "SUBSCRIBE_NOW",

--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -63,7 +63,12 @@ class PaypalProvider(BasicProvider):
     """
 
     def __init__(
-        self, client_id, secret, endpoint="https://api.sandbox.paypal.com", capture=True, **kwargs
+        self,
+        client_id,
+        secret,
+        endpoint="https://api.sandbox.paypal.com",
+        capture=True,
+        **kwargs,
     ):
         self.secret = secret
         self.client_id = client_id
@@ -76,7 +81,7 @@ class PaypalProvider(BasicProvider):
         self.payment_refund_url = (
             self.endpoint + "/v1/payments/capture/{captureId}/refund"
         )
-        self.plan_id = kwargs.get('plan_id', None)
+        self.plan_id = kwargs.get("plan_id", None)
         super().__init__(capture=capture)
 
     def set_response_data(self, payment, response, is_auth=False):
@@ -116,7 +121,7 @@ class PaypalProvider(BasicProvider):
         }
         if "data" in kwargs:
             kwargs["data"] = json.dumps(kwargs["data"])
-        http_method = kwargs.pop('http_method', requests.post)
+        http_method = kwargs.pop("http_method", requests.post)
         response = http_method(*args, **kwargs)
         try:
             data = response.json()
@@ -292,7 +297,7 @@ class PaypalProvider(BasicProvider):
             subscription_data = self.get_subscription(payment)
         except PaymentError:
             return redirect(failure_url)
-        if subscription_data['status'] == 'ACTIVE':
+        if subscription_data["status"] == "ACTIVE":
             payment.captured_amount = payment.total
             payment.change_status(PaymentStatus.CONFIRMED)
             return redirect(success_url)
@@ -308,18 +313,18 @@ class PaypalProvider(BasicProvider):
         plan_data = {
             "plan_id": plan_id,
             "application_context": {
-                'shipping_preference': 'NO_SHIPPING',
+                "shipping_preference": "NO_SHIPPING",
                 "user_action": "SUBSCRIBE_NOW",
                 "payment_method": {
                     "payer_selected": "PAYPAL",
-                    "payee_preferred": "IMMEDIATE_PAYMENT_REQUIRED"
+                    "payee_preferred": "IMMEDIATE_PAYMENT_REQUIRED",
                 },
                 **redirect_urls,
-            }
+            },
         }
         payment_data = self.post(payment, self.subscriptions_url, data=plan_data)
         subscription = payment.get_subscription()
-        subscription.set_recurrence(payment_data['id'])
+        subscription.set_recurrence(payment_data["id"])
         return payment_data
 
     def cancel_subscription(self, subscription):

--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -313,20 +313,26 @@ class PaypalProvider(BasicProvider):
         plan_data = {
             "plan_id": plan_id,
             "plan": {  # Override plan values
-                "billing_cycles": [{
-                    "sequence": 1,
-                    # TODO: This doesn't work:
-                    # "frequency": {
-                    #     "interval_unit": payment.get_subscription().get_unit(),
-                    #     "interval_count": payment.get_subscription().get_period(),
-                    # },
-                    "pricing_scheme": {
-                        "fixed_price": {
-                            "currency_code": payment.currency,
-                            "value": str(payment.total.quantize(CENTS, rounding=ROUND_HALF_UP)),
+                "billing_cycles": [
+                    {
+                        "sequence": 1,
+                        # TODO: This doesn't work:
+                        # "frequency": {
+                        #     "interval_unit": payment.get_subscription().get_unit(),
+                        #     "interval_count": payment.get_subscription().get_period(),
+                        # },
+                        "pricing_scheme": {
+                            "fixed_price": {
+                                "currency_code": payment.currency,
+                                "value": str(
+                                    payment.total.quantize(
+                                        CENTS, rounding=ROUND_HALF_UP
+                                    )
+                                ),
+                            },
                         },
-                    },
-                }],
+                    }
+                ],
             },
             "application_context": {
                 "shipping_preference": "NO_SHIPPING",


### PR DESCRIPTION
This is partially working implementation of PayPal subscriptions. I was able to manage subscription creation, getting state and cancelling. This is based subscription support drafted in #217.

Although I was able to successfully manage communication with PayPal, I have got stuck and I don't know how to continue at this point. The main problems are:

**PayPal requires setting `plan_id` and having Plan created at the time of creating the Subscription.**
This is not required when using Subscription button (like `django-paypal` does). It brings in whole lot of problems - the price can't be changed per user, it requires implementer to set up the Plans on PayPal and maintain consistency with server settings (especially if `django-payments` are used with multiple providers).

**Getting notification of the payments**
I don't know how to capture the recurring payments. With PayPal Subscription buttons PayPal sends notification about the payment. I didn't find how to do that with API. There also might be possibility to check the Subscriptions through the API and  check their (possibly changed) expiration.