### PR TITLE
Add check-yaml to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
       - id: end-of-file-fixer
       - id: check-toml
+      - id: check-yaml
       - id: check-added-large-files
       - id: debug-statements
   - repo: https://github.com/pycqa/isort
@@ -29,7 +30,7 @@ repos:
     -   id: pyupgrade
         args: [--py3-plus]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.940"
+    rev: "v0.941"
     hooks:
       - id: mypy
         additional_dependencies:


### PR DESCRIPTION
To help avoid problems like https://github.com/jazzband/django-payments/pull/302 -> https://github.com/jazzband/django-payments/commit/b755a348869037465a038c44f49199d8a1911692.

And run `pre-commit autoupdate`.