### PR TITLE
Bugfix for Cybersource. Wrong exception was except

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -110,6 +110,12 @@ accomplished by passing your data to the :class:`Payment` instance::
 
       >>> payment.attrs.merchant_defined_data = {'01': 'foo', '02': 'bar'}
 
+Fingerprinting::
+
+Cybersource allows you to pass a fingerprint data to help identify fraud
+
+      >>> payment.attrs.fingerprint_session_id
+
 
 Dotpay
 ------

--- a/payments/cybersource/__init__.py
+++ b/payments/cybersource/__init__.py
@@ -280,7 +280,7 @@ class CyberSourceProvider(BasicProvider):
         }
         try:
             fingerprint_id = payment.attrs.fingerprint_session_id
-        except KeyError:
+        except AttributeError:
             pass
         else:
             params["deviceFingerprintID"] = fingerprint_id
@@ -446,7 +446,7 @@ class CyberSourceProvider(BasicProvider):
     def _prepare_merchant_defined_data(self, payment):
         try:
             merchant_defined_data = payment.attrs.merchant_defined_data
-        except KeyError:
+        except AttributeError:
             return
         else:
             data = self.client.factory.create("data:MerchantDefinedData")


### PR DESCRIPTION
Bugfix and added documentation about a feature

Optional parameters

- payment.attrs.fingerprint_session_id
- payment.attrs.merchant_defined_data

error was thrown if the parameters above were not included, but that doesn't appear to be the intended design
Was caused by the wrong exception being captured
Issue  #323