### PR TITLE
Django phonenumber field pinning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,4 @@ addopts =
   --color=yes
 testpaths = payments
 DJANGO_SETTINGS_MODULE = test_settings
+pythonpath = .

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires=[
         "Django>=2.2",
         "requests>=1.2.0",
-        "django-phonenumber-field[phonenumberslite]>=6.0.0",
+        "django-phonenumber-field[phonenumberslite]>=5.0.0",
     ],
     extras_require={
         "braintree": ["braintree>=3.14.0"],


### PR DESCRIPTION
I tested `django-phonenumber-field[phonenumberslite]==5.0.0` with all configurations in tox.ini and it works with  django 3.2 and below. Version `5.1.0` works with all python/django combinations in tox.

Resolves #338