### PR TITLE
Expiration field label is not translated #278

### DIFF
--- a/payments/forms.py
+++ b/payments/forms.py
@@ -42,7 +42,7 @@ class PaymentForm(forms.Form):
 
 class CreditCardPaymentForm(PaymentForm):
     number = CreditCardNumberField(label=_("Card Number"), max_length=32, required=True)
-    expiration = CreditCardExpiryField()
+    expiration = CreditCardExpiryField(label=_('Expiration'))
     cvv2 = CreditCardVerificationField(
         label=_("CVV2 Security Number"),
         required=False,

--- a/payments/forms.py
+++ b/payments/forms.py
@@ -42,7 +42,7 @@ class PaymentForm(forms.Form):
 
 class CreditCardPaymentForm(PaymentForm):
     number = CreditCardNumberField(label=_("Card Number"), max_length=32, required=True)
-    expiration = CreditCardExpiryField(label=_('Expiration'))
+    expiration = CreditCardExpiryField(label=_("Expiration"))
     cvv2 = CreditCardVerificationField(
         label=_("CVV2 Security Number"),
         required=False,


### PR DESCRIPTION
https://github.com/jazzband/django-payments/issues/278
Added label translation to `CreditCardExpiryField`