### PR TITLE
Added captured amount to DummyProvider

### DIFF
--- a/payments/dummy/__init__.py
+++ b/payments/dummy/__init__.py
@@ -62,11 +62,13 @@ class DummyProvider(BasicProvider):
         if verification_result:
             payment.change_status(verification_result)
         if payment.status in [PaymentStatus.CONFIRMED, PaymentStatus.PREAUTH]:
+            payment.captured_amount = payment.total
             return HttpResponseRedirect(payment.get_success_url())
         return HttpResponseRedirect(payment.get_failure_url())
 
     def capture(self, payment, amount=None):
         payment.change_status(PaymentStatus.CONFIRMED)
+        payment.captured_amount = payment.total
         return amount
 
     def release(self, payment):

--- a/payments/dummy/__init__.py
+++ b/payments/dummy/__init__.py
@@ -68,7 +68,7 @@ class DummyProvider(BasicProvider):
 
     def capture(self, payment, amount=None):
         payment.change_status(PaymentStatus.CONFIRMED)
-        payment.captured_amount = payment.total
+        payment.captured_amount = (amount or payment.total)
         return amount
 
     def release(self, payment):

--- a/payments/dummy/__init__.py
+++ b/payments/dummy/__init__.py
@@ -68,7 +68,7 @@ class DummyProvider(BasicProvider):
 
     def capture(self, payment, amount=None):
         payment.change_status(PaymentStatus.CONFIRMED)
-        payment.captured_amount = (amount or payment.total)
+        payment.captured_amount = amount or payment.total
         return amount
 
     def release(self, payment):

--- a/payments/dummy/test_dummy.py
+++ b/payments/dummy/test_dummy.py
@@ -22,6 +22,7 @@ class Payment:
     total = 100
     status = PaymentStatus.WAITING
     fraud_status = ""
+    captured_amount = 0
 
     def get_process_url(self):
         return "http://example.com"
@@ -50,6 +51,7 @@ class TestDummy3DSProvider(TestCase):
         request.GET = {"verification_result": verification_status}
         response = provider.process_data(self.payment, request)
         self.assertEqual(self.payment.status, verification_status)
+        self.assertEqual(self.payment.captured_amount, 100)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["location"], self.payment.get_success_url())
 


### PR DESCRIPTION
I think that this would solve https://github.com/jazzband/django-payments/issues/374 bug, at least for a full captured amount.
Maybe in a future consider a more complex scenario like parcial captures 🤔 

What do you think? Should this be optionally?