### PR TITLE
Drop support for older EOL Django versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        django-version: ['2.2', '3.2', '4.1', '4.2', 'main']
+        django-version: ['3.2', '4.1', '4.2', 'main']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,10 @@ Changelog
 This file contains a brief summary of new features and dependency changes or
 releases, in reverse chronological order.
 
-v2.1.0
+v3.0.0
 ------
+- **BREAKING**: Dropped support for Django 2.2, 3.0, 3.1 and 4.0.
+  Supported versions of Django are 3.2 (LTS), 4.1 and 4.2.
 - Stripe backends now sends order_id in the metadata parameter.
 - A new ``StripeProviderV3`` has been added using the latest Stripe API.
 - Added support for Python 3.11, Django 4.1 and Django 4.2.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,7 @@ keywords = ["payments"]
 license = {text = "BSD"}
 classifiers = [
     "Environment :: Web Environment",
-    "Framework :: Django :: 2.2",
-    "Framework :: Django :: 3.0",
-    "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Intended Audience :: Developers",
@@ -33,7 +29,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "Django>=2.2",
+    "Django>=3.2",
     "requests>=1.2.0",
     "django-phonenumber-field[phonenumberslite]>=5.0.0",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{38,39}-dj{22,30,31,32}
-    py{38,39,310}-dj40
+    py{38,39}-dj32
     py{38,39,310,311}-dj{41,42}
     py{310,311,312}-djmain
 skip_missing_interpreters = true
@@ -13,11 +12,7 @@ ignore_outcome =
 ignore_errors =
     djmain: True
 deps=
-    dj22: Django>=2.2,<3.0
-    dj30: Django>=3.0,<3.1
-    dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
-    dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<5.0
     djmain: https://github.com/django/django/archive/main.tar.gz
@@ -43,11 +38,7 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    2.2: dj22
-    3.0: dj30
-    3.1: dj31
     3.2: dj32
-    4.0: dj40
     4.1: dj41
     4.2: dj42
     main: djmain


### PR DESCRIPTION
My intent was to drop just Django 2.2, but given that this is a breaking change, I'm dropping all versions past their EOL.