### PR TITLE
Move dev dependencies into the [dev] extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,13 @@ dynamic = ["version"]
 [project.optional-dependencies]
 braintree = ["braintree>=3.14.0"]
 cybersource = ["suds-community>=0.6"]
+dev = [
+    "coverage",
+    "mock",
+    "pytest",
+    "pytest-cov",
+    "pytest-django",
+]
 docs = ["sphinx_rtd_theme"]
 mercadopago = ["mercadopago>=2.0.0,<3.0.0"]
 sagepay = ["cryptography>=1.1.0"]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ ignore_outcome =
 ignore_errors =
     djmain: True
 deps=
-    coverage
     dj22: Django>=2.2,<3.0
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
@@ -22,13 +21,10 @@ deps=
     dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<5.0
     djmain: https://github.com/django/django/archive/main.tar.gz
-    mock
-    pytest
-    pytest-cov
-    pytest-django
 extras=
   braintree
   cybersource
+  dev
   mercadopago
   sagepay
   sofort


### PR DESCRIPTION
This makes is easy to install them into a virtualenv manually.