### PR TITLE
Stripe : move customer_data field to metadata

### DIFF
--- a/payments/stripe/providers.py
+++ b/payments/stripe/providers.py
@@ -131,7 +131,7 @@ class StripeProviderV3(BasicProvider):
                 session_data.update(
                     {
                         "metadata": {
-                            "customer_name": f"{payment.billing_first_name} " 
+                            "customer_name": f"{payment.billing_first_name} "
                             f"{payment.billing_last_name}"
                         }
                     }

--- a/payments/stripe/providers.py
+++ b/payments/stripe/providers.py
@@ -130,8 +130,8 @@ class StripeProviderV3(BasicProvider):
             if payment.billing_first_name or payment.billing_last_name:
                 session_data.update(
                     {
-                        "customer_data": {
-                            "customer_name": f"{payment.billing_first_name} "
+                        "metadata": {
+                            "customer_name": f"{payment.billing_first_name} " 
                             f"{payment.billing_last_name}"
                         }
                     }

--- a/payments/stripe/test_stripev3.py
+++ b/payments/stripe/test_stripev3.py
@@ -107,6 +107,12 @@ class TestStripeProviderV3(TestCase):
         with patch("stripe.checkout.Session.create"), self.assertRaises(PaymentError):
             provider.create_session(payment)
 
+    def test_provider_create_session_success_with_billing_name(self):
+        payment = Payment()
+        payment.billing_name = "Billy Ngname"
+        provider = StripeProviderV3(api_key=API_KEY)
+        provider.create_session(payment)
+
     def test_provider_status(self):
         payment = Payment()
         provider = StripeProviderV3(api_key=API_KEY)


### PR DESCRIPTION
Ref https://github.com/jazzband/django-payments/issues/378

--- 

[In stripe/providers.py](https://github.com/jazzband/django-payments/blob/main/payments/stripe/providers.py#L131-L137) the field customer_data does not seem to be defined in [Stripe API's Session object](https://docs.stripe.com/api/checkout/sessions/object)

It could be moved to the metadata field (from Stripe's documentation) :

>  Set of [key-value pairs](https://docs.stripe.com/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.