### PR TITLE
PayPal: Perform full refund if amount=None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ v3.0.0
 - New :ref:`webhook settings <webhooks>`
 - Fixed PayPal backends not saving captured_amount when processing data.
 - Fixed ``base_payment.refund()`` not making any refund
+- PayPal backends now perform a full refund if ``amount=None``.
 
 v2.0.0
 ------


### PR DESCRIPTION
Since PayPal does support refunding without an amount specified and django-payment's API as well, it makes sense to me.

The benefit is that for various reasons the local copy of the payment (`BasePayment.captured_amount`) may get easily desynchronized with the payment gateway (e.g. bugs like this https://github.com/jazzband/django-payments/issues/309 (see https://github.com/jazzband/django-payments/pull/412)). This performs the full refund regardless of the `BasePayment.captured_amount`.

This change will have an effect only if https://github.com/jazzband/django-payments/issues/401 gets fixed (see https://github.com/jazzband/django-payments/pull/410) but it won't hurt otherwise too.

Feel free to request any necessary changes :pray: 