### PR TITLE
PayPal: Save captured_amount when processing data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ v3.0.0
 - Added support for Python 3.11, Django 4.1 and Django 4.2.
 - Stripe backends now supports webhooks
 - New :ref:`webhook settings <webhooks>`
+- Fixed PayPal backends not saving captured_amount when processing data.
 
 v2.0.0
 ------

--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -252,6 +252,9 @@ class PaypalProvider(BasicProvider):
         payment.attrs.payer_info = executed_payment["payer"]["payer_info"]
         if self._capture:
             payment.captured_amount = payment.total
+            type(payment).objects.filter(pk=payment.pk).update(
+                captured_amount=payment.captured_amount
+            )
             payment.change_status(PaymentStatus.CONFIRMED)
         else:
             payment.change_status(PaymentStatus.PREAUTH)


### PR DESCRIPTION
Partially fixes: https://github.com/jazzband/django-payments/issues/309

Similar work needs to be done on multiple places though but this particular part prevents us from performing proper refunds.

Feel free to request any necessary changes 🙏