### PR TITLE
Improve doc about get_process_url.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -72,6 +72,12 @@ This includes two sets of URLs:
 
 None of these views render any "pages" that your users might every see.
 
+.. note::
+
+  If you include the `payments` URLs within a namespaced app (e.g., inside 
+  `myproject/myapp/urls.py`), you will need to override the `get_process_url`
+  method in your `Payment` class (see later on documentation).
+
 .. _settings:
 
 Additional Django settings

--- a/docs/payment-model.rst
+++ b/docs/payment-model.rst
@@ -50,6 +50,11 @@ Example implementation
                   currency='USD',
               )
 
+          # OPTIONAL: If you are using django-payments within a namespaced app,
+          # you need to override get_process_url to include your namespace.
+          def get_process_url(self) -> str:
+              return reverse("REPLACE_YOUR_NAMESPACE:process_payment", kwargs={"token": self.token})
+
 Create a payment view
 ---------------------
 


### PR DESCRIPTION
## Description

This PR improves the *Django Payments* documentation by clarifying how to configure URL patterns when using the package inside a namespaced app. It adds a note explaining the need to override `get_process_url` to ensure proper URL resolution. Additionally, it includes an example of how to modify `get_process_url` to include the correct namespace.

## Why This Matters

Without this clarification, users implementing *django-payments* within a namespaced app may encounter issues where the `process_payment` URL cannot be resolved.

Related Issue
Fixes #396