### PR TITLE
PaypalProvider: allow to make also get requests

### DIFF
--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -122,14 +122,24 @@ class PaypalProvider(BasicProvider):
         return extra_data.get("links", {})
 
     @authorize
-    def http_request(self, payment, *args, http_method=None, **kwargs):
+    def http_request(self, payment, *args, method: str = "get", **kwargs) -> dict:
+        """Perform an authorized request to the PayPal API.
+
+        :param payment: Payment instance (can be None for requests not tied
+            to a payment)
+        :param args: positional arguments passed to :func:`requests.request`
+        :param method: HTTP method name, e.g. ``"get"`` or ``"post"``
+        :param kwargs: keyword arguments passed to :func:`requests.request`
+        :returns: JSON response data from the PayPal API
+        :raises PaymentError: if the API returns an error status code
+        """
         kwargs["headers"] = {
             "Content-Type": "application/json",
             "Authorization": self.access_token,
         }
         if "data" in kwargs:
             kwargs["data"] = json.dumps(kwargs["data"])
-        response = http_method(*args, **kwargs)
+        response = requests.request(method, *args, **kwargs)
         try:
             data = response.json()
         except ValueError:
@@ -155,39 +165,29 @@ class PaypalProvider(BasicProvider):
             self.set_response_data(payment, data)
         return data
 
-    def post(self, payment, *args, **kwargs):
+    def post(self, payment, *args, **kwargs) -> dict:
+        """Perform a POST request to the PayPal API.
+
+        :param payment: Payment instance (can be None for requests not tied
+            to a payment)
+        :param args: positional arguments passed to :func:`requests.request`
+        :param kwargs: keyword arguments passed to :func:`requests.request`
+        :returns: JSON response data from the PayPal API
+        :raises PaymentError: if the API returns an error status code
         """
-        Perform a POST request to the PayPal API.
+        return self.http_request(payment, *args, method="post", **kwargs)
 
-        Args:
-            payment: Payment instance (can be None for requests not tied to a payment)
-            *args: Positional arguments passed to requests.post()
-            **kwargs: Keyword arguments passed to requests.post()
+    def get(self, payment, *args, **kwargs) -> dict:
+        """Perform a GET request to the PayPal API.
 
-        Returns:
-            dict: JSON response data from PayPal API
-
-        Raises:
-            PaymentError: If the API returns an error status code
+        :param payment: Payment instance (can be None for requests not tied
+            to a payment)
+        :param args: positional arguments passed to :func:`requests.request`
+        :param kwargs: keyword arguments passed to :func:`requests.request`
+        :returns: JSON response data from the PayPal API
+        :raises PaymentError: if the API returns an error status code
         """
-        return self.http_request(payment, *args, http_method=requests.post, **kwargs)
-
-    def get(self, payment, *args, **kwargs):
-        """
-        Perform a GET request to the PayPal API.
-
-        Args:
-            payment: Payment instance (can be None for requests not tied to a payment)
-            *args: Positional arguments passed to requests.get()
-            **kwargs: Keyword arguments passed to requests.get()
-
-        Returns:
-            dict: JSON response data from PayPal API
-
-        Raises:
-            PaymentError: If the API returns an error status code
-        """
-        return self.http_request(payment, *args, http_method=requests.get, **kwargs)
+        return self.http_request(payment, *args, method="get", **kwargs)
 
     def get_last_response(self, payment, is_auth=False):
         extra_data = json.loads(payment.extra_data or "{}")

--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -43,10 +43,13 @@ def authorize(fun):
             response = fun(*args, **kwargs)
         except HTTPError as e:
             if e.response.status_code == 401:
-                last_auth_response = self.get_last_response(payment, is_auth=True)
-                if "access_token" in last_auth_response:
-                    del last_auth_response["access_token"]
-                    self.set_response_data(payment, last_auth_response, is_auth=True)
+                if payment is not None:
+                    last_auth_response = self.get_last_response(payment, is_auth=True)
+                    if "access_token" in last_auth_response:
+                        del last_auth_response["access_token"]
+                        self.set_response_data(
+                            payment, last_auth_response, is_auth=True
+                        )
                 self.access_token = self.get_access_token(payment)
                 response = fun(*args, **kwargs)
             else:
@@ -197,10 +200,11 @@ class PaypalProvider(BasicProvider):
             last_auth_response = self.get_last_response(payment, is_auth=True)
             created = payment.created
             now = timezone.now()
+            expires_in = last_auth_response.get("expires_in")
             if (
                 "access_token" in last_auth_response
-                and "expires_in" in last_auth_response
-                and (created + timedelta(seconds=last_auth_response["expires_in"])) > now
+                and expires_in is not None
+                and (created + timedelta(seconds=expires_in)) > now
             ):
                 return "{} {}".format(
                     last_auth_response["token_type"], last_auth_response["access_token"]

--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -119,20 +119,21 @@ class PaypalProvider(BasicProvider):
         return extra_data.get("links", {})
 
     @authorize
-    def post(self, payment, *args, **kwargs):
+    def http_request(self, payment, *args, http_method=None, **kwargs):
         kwargs["headers"] = {
             "Content-Type": "application/json",
             "Authorization": self.access_token,
         }
         if "data" in kwargs:
             kwargs["data"] = json.dumps(kwargs["data"])
-        response = requests.post(*args, **kwargs)
+        response = http_method(*args, **kwargs)
         try:
             data = response.json()
         except ValueError:
             data = {}
         if 400 <= response.status_code <= 500:
-            self.set_error_data(payment, data)
+            if payment is not None:
+                self.set_error_data(payment, data)
             logger.debug(data)
             message = "Paypal error"
             if response.status_code == 400:
@@ -144,10 +145,46 @@ class PaypalProvider(BasicProvider):
                 message = error_data.get("message", message)
             else:
                 logger.warning(message, extra={"status_code": response.status_code})
-            payment.change_status(PaymentStatus.ERROR, message)
+            if payment is not None:
+                payment.change_status(PaymentStatus.ERROR, message)
             raise PaymentError(message)
-        self.set_response_data(payment, data)
+        if payment is not None:
+            self.set_response_data(payment, data)
         return data
+
+    def post(self, payment, *args, **kwargs):
+        """
+        Perform a POST request to the PayPal API.
+
+        Args:
+            payment: Payment instance (can be None for requests not tied to a payment)
+            *args: Positional arguments passed to requests.post()
+            **kwargs: Keyword arguments passed to requests.post()
+
+        Returns:
+            dict: JSON response data from PayPal API
+
+        Raises:
+            PaymentError: If the API returns an error status code
+        """
+        return self.http_request(payment, *args, http_method=requests.post, **kwargs)
+
+    def get(self, payment, *args, **kwargs):
+        """
+        Perform a GET request to the PayPal API.
+
+        Args:
+            payment: Payment instance (can be None for requests not tied to a payment)
+            *args: Positional arguments passed to requests.get()
+            **kwargs: Keyword arguments passed to requests.get()
+
+        Returns:
+            dict: JSON response data from PayPal API
+
+        Raises:
+            PaymentError: If the API returns an error status code
+        """
+        return self.http_request(payment, *args, http_method=requests.get, **kwargs)
 
     def get_last_response(self, payment, is_auth=False):
         extra_data = json.loads(payment.extra_data or "{}")
@@ -156,17 +193,18 @@ class PaypalProvider(BasicProvider):
         return extra_data.get("response", {})
 
     def get_access_token(self, payment):
-        last_auth_response = self.get_last_response(payment, is_auth=True)
-        created = payment.created
-        now = timezone.now()
-        if (
-            "access_token" in last_auth_response
-            and "expires_in" in last_auth_response
-            and (created + timedelta(seconds=last_auth_response["expires_in"])) > now
-        ):
-            return "{} {}".format(
-                last_auth_response["token_type"], last_auth_response["access_token"]
-            )
+        if payment is not None:
+            last_auth_response = self.get_last_response(payment, is_auth=True)
+            created = payment.created
+            now = timezone.now()
+            if (
+                "access_token" in last_auth_response
+                and "expires_in" in last_auth_response
+                and (created + timedelta(seconds=last_auth_response["expires_in"])) > now
+            ):
+                return "{} {}".format(
+                    last_auth_response["token_type"], last_auth_response["access_token"]
+                )
         headers = {"Accept": "application/json", "Accept-Language": "en_US"}
         post = {"grant_type": "client_credentials"}
         response = requests.post(
@@ -177,8 +215,9 @@ class PaypalProvider(BasicProvider):
         )
         response.raise_for_status()
         data = response.json()
-        last_auth_response.update(data)
-        self.set_response_data(payment, last_auth_response, is_auth=True)
+        if payment is not None:
+            last_auth_response.update(data)
+            self.set_response_data(payment, last_auth_response, is_auth=True)
         return "{} {}".format(data["token_type"], data["access_token"])
 
     def get_transactions_items(self, payment):

--- a/payments/paypal/test_paypal.py
+++ b/payments/paypal/test_paypal.py
@@ -214,7 +214,10 @@ def test_provider_raises_redirect_needed_on_success(
     paypal_payment: Payment,
     paypal_provider: PaypalProvider,
 ) -> None:
-    with patch("requests.post") as mocked_post:
+    with (
+        patch("requests.post") as mocked_post,
+        patch("requests.request") as mocked_request,
+    ):
         transaction_id = "1234"
         data = MagicMock()
         data.return_value = {
@@ -227,6 +230,7 @@ def test_provider_raises_redirect_needed_on_success(
         post.json = data
         post.status_code = 200
         mocked_post.return_value = post
+        mocked_request.return_value = post
         with pytest.raises(RedirectNeeded):
             paypal_provider.get_form(payment=paypal_payment)
 
@@ -235,9 +239,11 @@ def test_provider_raises_redirect_needed_on_success(
     assert paypal_payment.transaction_id == transaction_id
 
 
+@patch("requests.request")
 @patch("requests.post")
 def test_provider_captures_payment(
     mocked_post: MagicMock,
+    mocked_request: MagicMock,
     paypal_payment: Payment,
     paypal_provider: PaypalProvider,
 ) -> None:
@@ -251,6 +257,7 @@ def test_provider_captures_payment(
     post.json = data
     post.status_code = 200
     mocked_post.return_value = post
+    mocked_request.return_value = post
     paypal_provider.capture(paypal_payment)
     assert paypal_payment.status == PaymentStatus.CONFIRMED
 
@@ -268,23 +275,28 @@ def test_provider_handles_captured_payment(
     assert paypal_payment.status == PaymentStatus.CONFIRMED
 
 
+@patch("requests.request")
 @patch("requests.post")
 def test_provider_refunds_payment_fully(
     mocked_post: MagicMock,
+    mocked_request: MagicMock,
     paypal_payment: Payment,
     paypal_provider: PaypalProvider,
 ) -> None:
-    data = MagicMock()
-    data.side_effect = [
-        {"token_type": "test_token_type", "access_token": "test_access_token"},
-        {"amount": {"total": "220.00", "currency": "USD"}},
-    ]
-    post = MagicMock()
-    post.json = data
-    post.status_code = 200
-    mocked_post.return_value = post
+    token = MagicMock()
+    token.json.return_value = {
+        "token_type": "test_token_type",
+        "access_token": "test_access_token",
+    }
+    token.status_code = 200
+    mocked_post.return_value = token
+    refund = MagicMock()
+    refund.json.return_value = {"amount": {"total": "220.00", "currency": "USD"}}
+    refund.status_code = 200
+    mocked_request.return_value = refund
     paypal_provider.refund(paypal_payment)
-    mocked_post.assert_called_with(
+    mocked_request.assert_called_with(
+        "post",
         "http://refund.com",
         headers={
             "Content-Type": "application/json",
@@ -295,21 +307,28 @@ def test_provider_refunds_payment_fully(
     assert paypal_payment.status == PaymentStatus.REFUNDED
 
 
+@patch("requests.request")
 @patch("requests.post")
 def test_provider_refunds_payment_partially(
-    mocked_post: MagicMock, paypal_payment: Payment, paypal_provider: PaypalProvider
+    mocked_post: MagicMock,
+    mocked_request: MagicMock,
+    paypal_payment: Payment,
+    paypal_provider: PaypalProvider,
 ) -> None:
-    data = MagicMock()
-    data.side_effect = [
-        {"token_type": "test_token_type", "access_token": "test_access_token"},
-        {"amount": {"total": "1.00", "currency": "USD"}},
-    ]
-    post = MagicMock()
-    post.json = data
-    post.status_code = 200
-    mocked_post.return_value = post
+    token = MagicMock()
+    token.json.return_value = {
+        "token_type": "test_token_type",
+        "access_token": "test_access_token",
+    }
+    token.status_code = 200
+    mocked_post.return_value = token
+    refund = MagicMock()
+    refund.json.return_value = {"amount": {"total": "1.00", "currency": "USD"}}
+    refund.status_code = 200
+    mocked_request.return_value = refund
     paypal_provider.refund(paypal_payment, amount=Decimal(1))
-    mocked_post.assert_called_with(
+    mocked_request.assert_called_with(
+        "post",
         "http://refund.com",
         headers={
             "Content-Type": "application/json",
@@ -320,11 +339,13 @@ def test_provider_refunds_payment_partially(
     assert paypal_payment.status == PaymentStatus.REFUNDED
 
 
+@patch("requests.request")
 @patch("requests.post")
 @patch("payments.paypal.redirect")
 def test_provider_redirects_on_success_captured_payment(
     mocked_redirect: MagicMock,
     mocked_post: MagicMock,
+    mocked_request: MagicMock,
     paypal_payment: Payment,
     paypal_provider: PaypalProvider,
 ) -> None:
@@ -345,6 +366,7 @@ def test_provider_redirects_on_success_captured_payment(
     post.json = data
     post.status_code = 200
     mocked_post.return_value = post
+    mocked_request.return_value = post
 
     request = MagicMock()
     request.GET = {"token": "test", "PayerID": "1234"}
@@ -357,10 +379,14 @@ def test_provider_redirects_on_success_captured_payment(
     assert paypal_payment.captured_amount == paypal_payment.total
 
 
+@patch("requests.request")
 @patch("requests.post")
 @patch("payments.paypal.redirect")
 def test_provider_redirects_on_success_preauth_payment(
-    mocked_redirect: MagicMock, mocked_post: MagicMock, paypal_payment: Payment
+    mocked_redirect: MagicMock,
+    mocked_post: MagicMock,
+    mocked_request: MagicMock,
+    paypal_payment: Payment,
 ) -> None:
     data = MagicMock()
     data.return_value = {
@@ -379,6 +405,7 @@ def test_provider_redirects_on_success_preauth_payment(
     post.json = data
     post.status_code = 200
     mocked_post.return_value = post
+    mocked_request.return_value = post
 
     request = MagicMock()
     request.GET = {"token": "test", "PayerID": "1234"}
@@ -404,9 +431,11 @@ def test_provider_request_without_payerid_redirects_on_failure(
     assert paypal_payment.status == PaymentStatus.REJECTED
 
 
+@patch("requests.request")
 @patch("requests.post")
 def test_provider_renews_access_token(
     mocked_post: MagicMock,
+    mocked_request: MagicMock,
     paypal_payment: Payment,
     paypal_provider: PaypalProvider,
 ) -> None:
@@ -418,7 +447,9 @@ def test_provider_renews_access_token(
     response = MagicMock()
     response.json = data
     response.status_code = 200
-    mocked_post.side_effect = [HTTPError(response=response401), response, response]
+    # The API call 401s, @authorize renews the token via oauth and retries.
+    mocked_request.side_effect = [HTTPError(response=response401), response]
+    mocked_post.return_value = response
 
     paypal_payment.created = timezone.now()
     paypal_payment.extra_data = json.dumps(
@@ -451,7 +482,10 @@ def paypal_card_provider() -> PaypalCardProvider:
 def test_provider_raises_redirect_needed_on_success_captured_payment_card(
     paypal_card_payment: Payment, paypal_card_provider: PaypalCardProvider
 ) -> None:
-    with patch("requests.post") as mocked_post:
+    with (
+        patch("requests.post") as mocked_post,
+        patch("requests.request") as mocked_request,
+    ):
         transaction_id = "1234"
         data = MagicMock()
         data.return_value = {
@@ -476,6 +510,7 @@ def test_provider_raises_redirect_needed_on_success_captured_payment_card(
         post.json = data
         post.status_code = 200
         mocked_post.return_value = post
+        mocked_request.return_value = post
         with pytest.raises(RedirectNeeded) as exc:
             paypal_card_provider.get_form(
                 payment=paypal_card_payment, data=PROCESS_DATA
@@ -493,7 +528,10 @@ def test_provider_raises_redirect_needed_on_success_preauth_payment_card(
     paypal_card_payment: Payment,
 ) -> None:
     provider = PaypalCardProvider(secret=SECRET, client_id=CLIENT_ID, capture=False)
-    with patch("requests.post") as mocked_post:
+    with (
+        patch("requests.post") as mocked_post,
+        patch("requests.request") as mocked_request,
+    ):
         transaction_id = "1234"
         data = MagicMock()
         data.return_value = {
@@ -519,6 +557,7 @@ def test_provider_raises_redirect_needed_on_success_preauth_payment_card(
         post.json = data
         post.status_code = 200
         mocked_post.return_value = post
+        mocked_request.return_value = post
         with pytest.raises(RedirectNeeded) as exc:
             provider.get_form(payment=paypal_card_payment, data=PROCESS_DATA)
         assert str(exc.value) == paypal_card_payment.get_success_url()
@@ -557,7 +596,10 @@ def test_provider_get_with_none_payment(paypal_provider: PaypalProvider) -> None
     expected_token = "test_access_token"
     expected_token_type = "Bearer"
 
-    with patch("requests.post") as mocked_post, patch("requests.get") as mocked_get:
+    with (
+        patch("requests.post") as mocked_post,
+        patch("requests.request") as mocked_request,
+    ):
         # Mock for token acquisition
         token_response_mock = MagicMock()
         token_response_mock.json.return_value = {
@@ -573,7 +615,7 @@ def test_provider_get_with_none_payment(paypal_provider: PaypalProvider) -> None
         get_response_mock.status_code = 200
 
         mocked_post.return_value = token_response_mock
-        mocked_get.return_value = get_response_mock
+        mocked_request.return_value = get_response_mock
 
         response_data = paypal_provider.get(None, test_url)
 
@@ -584,7 +626,8 @@ def test_provider_get_with_none_payment(paypal_provider: PaypalProvider) -> None
             auth=(paypal_provider.client_id, paypal_provider.secret),
         )
 
-        mocked_get.assert_called_once_with(
+        mocked_request.assert_called_once_with(
+            "get",
             test_url,
             headers={
                 "Content-Type": "application/json",
@@ -598,7 +641,10 @@ def test_form_shows_internal_error_message(
     paypal_card_payment: Payment,
     paypal_card_provider: PaypalCardProvider,
 ) -> None:
-    with patch("requests.post") as mocked_post:
+    with (
+        patch("requests.post") as mocked_post,
+        patch("requests.request") as mocked_request,
+    ):
         error_message = "error message"
         data = MagicMock()
         data.return_value = {
@@ -610,6 +656,7 @@ def test_form_shows_internal_error_message(
         post.status_code = 400
         post.json = data
         mocked_post.return_value = post
+        mocked_request.return_value = post
         with pytest.raises(PaymentError):
             paypal_card_provider.get_form(
                 payment=paypal_card_payment, data=PROCESS_DATA
@@ -618,14 +665,19 @@ def test_form_shows_internal_error_message(
     assert paypal_card_payment.message == error_message
 
 
-def test_provider_get_with_none_payment_handles_401(paypal_provider):
+def test_provider_get_with_none_payment_handles_401(
+    paypal_provider: PaypalProvider,
+) -> None:
     """Test that get() method with payment=None handles 401 errors correctly."""
     test_url = "http://example.com/api/test"
     expected_get_response_data = {"status": "success"}
     expected_token = "test_access_token"
     expected_token_type = "Bearer"
 
-    with patch("requests.post") as mocked_post, patch("requests.get") as mocked_get:
+    with (
+        patch("requests.post") as mocked_post,
+        patch("requests.request") as mocked_request,
+    ):
         # Mock for token acquisition (called twice due to 401 retry)
         token_response_mock = MagicMock()
         token_response_mock.json.return_value = {
@@ -644,7 +696,7 @@ def test_provider_get_with_none_payment_handles_401(paypal_provider):
         get_response_200.status_code = 200
 
         mocked_post.return_value = token_response_mock
-        mocked_get.side_effect = [
+        mocked_request.side_effect = [
             HTTPError(response=get_response_401),
             get_response_200,
         ]
@@ -653,6 +705,6 @@ def test_provider_get_with_none_payment_handles_401(paypal_provider):
 
         # Should have called post twice (initial token + retry after 401)
         assert mocked_post.call_count == 2
-        # Should have called get twice (initial 401 + retry)
-        assert mocked_get.call_count == 2
+        # Should have called the API twice (initial 401 + retry)
+        assert mocked_request.call_count == 2
         assert response_data == expected_get_response_data

--- a/payments/paypal/test_paypal.py
+++ b/payments/paypal/test_paypal.py
@@ -557,9 +557,7 @@ def test_provider_get_with_none_payment(paypal_provider: PaypalProvider) -> None
     expected_token = "test_access_token"
     expected_token_type = "Bearer"
 
-    with patch("requests.post") as mocked_post, patch(
-        "requests.get"
-    ) as mocked_get:
+    with patch("requests.post") as mocked_post, patch("requests.get") as mocked_get:
         # Mock for token acquisition
         token_response_mock = MagicMock()
         token_response_mock.json.return_value = {
@@ -627,9 +625,7 @@ def test_provider_get_with_none_payment_handles_401(paypal_provider):
     expected_token = "test_access_token"
     expected_token_type = "Bearer"
 
-    with patch("requests.post") as mocked_post, patch(
-        "requests.get"
-    ) as mocked_get:
+    with patch("requests.post") as mocked_post, patch("requests.get") as mocked_get:
         # Mock for token acquisition (called twice due to 401 retry)
         token_response_mock = MagicMock()
         token_response_mock.json.return_value = {
@@ -642,7 +638,7 @@ def test_provider_get_with_none_payment_handles_401(paypal_provider):
         # Mock for the GET request - first 401, then success
         get_response_401 = MagicMock()
         get_response_401.status_code = 401
-        
+
         get_response_200 = MagicMock()
         get_response_200.json.return_value = expected_get_response_data
         get_response_200.status_code = 200
@@ -650,7 +646,7 @@ def test_provider_get_with_none_payment_handles_401(paypal_provider):
         mocked_post.return_value = token_response_mock
         mocked_get.side_effect = [
             HTTPError(response=get_response_401),
-            get_response_200
+            get_response_200,
         ]
 
         response_data = paypal_provider.get(None, test_url)

--- a/payments/paypal/test_paypal.py
+++ b/payments/paypal/test_paypal.py
@@ -550,6 +550,52 @@ def test_form_shows_validation_error_message(
     assert form.errors["__all__"][0] == error_message
 
 
+def test_provider_get_with_none_payment(paypal_provider: PaypalProvider) -> None:
+    """Test that get() method works with payment=None."""
+    test_url = "http://example.com/api/test"
+    expected_get_response_data = {"status": "success"}
+    expected_token = "test_access_token"
+    expected_token_type = "Bearer"
+
+    with patch("requests.post") as mocked_post, patch(
+        "requests.get"
+    ) as mocked_get:
+        # Mock for token acquisition
+        token_response_mock = MagicMock()
+        token_response_mock.json.return_value = {
+            "access_token": expected_token,
+            "token_type": expected_token_type,
+            "expires_in": 3600,
+        }
+        token_response_mock.status_code = 200
+
+        # Mock for the actual GET request
+        get_response_mock = MagicMock()
+        get_response_mock.json.return_value = expected_get_response_data
+        get_response_mock.status_code = 200
+
+        mocked_post.return_value = token_response_mock
+        mocked_get.return_value = get_response_mock
+
+        response_data = paypal_provider.get(None, test_url)
+
+        mocked_post.assert_called_once_with(
+            paypal_provider.oauth2_url,
+            data={"grant_type": "client_credentials"},
+            headers={"Accept": "application/json", "Accept-Language": "en_US"},
+            auth=(paypal_provider.client_id, paypal_provider.secret),
+        )
+
+        mocked_get.assert_called_once_with(
+            test_url,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"{expected_token_type} {expected_token}",
+            },
+        )
+        assert response_data == expected_get_response_data
+
+
 def test_form_shows_internal_error_message(
     paypal_card_payment: Payment,
     paypal_card_provider: PaypalCardProvider,

--- a/payments/paypal/test_paypal.py
+++ b/payments/paypal/test_paypal.py
@@ -618,3 +618,45 @@ def test_form_shows_internal_error_message(
             )
     assert paypal_card_payment.status == PaymentStatus.ERROR
     assert paypal_card_payment.message == error_message
+
+
+def test_provider_get_with_none_payment_handles_401(paypal_provider):
+    """Test that get() method with payment=None handles 401 errors correctly."""
+    test_url = "http://example.com/api/test"
+    expected_get_response_data = {"status": "success"}
+    expected_token = "test_access_token"
+    expected_token_type = "Bearer"
+
+    with patch("requests.post") as mocked_post, patch(
+        "requests.get"
+    ) as mocked_get:
+        # Mock for token acquisition (called twice due to 401 retry)
+        token_response_mock = MagicMock()
+        token_response_mock.json.return_value = {
+            "access_token": expected_token,
+            "token_type": expected_token_type,
+            "expires_in": 3600,
+        }
+        token_response_mock.status_code = 200
+
+        # Mock for the GET request - first 401, then success
+        get_response_401 = MagicMock()
+        get_response_401.status_code = 401
+        
+        get_response_200 = MagicMock()
+        get_response_200.json.return_value = expected_get_response_data
+        get_response_200.status_code = 200
+
+        mocked_post.return_value = token_response_mock
+        mocked_get.side_effect = [
+            HTTPError(response=get_response_401),
+            get_response_200
+        ]
+
+        response_data = paypal_provider.get(None, test_url)
+
+        # Should have called post twice (initial token + retry after 401)
+        assert mocked_post.call_count == 2
+        # Should have called get twice (initial 401 + retry)
+        assert mocked_get.call_count == 2
+        assert response_data == expected_get_response_data


### PR DESCRIPTION
PaypalProvider: Add also `get()` method to be able to use the provider to create also GET request to PayPal API.