### PR TITLE
PayPal: add an extra_data_key_refund parameter to the providers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 This file contains a brief summary of new features and dependency changes or
 releases, in reverse chronological order.
 
+v3.0.2
+------
+
+- Added a ``extra_data_key_refund`` parameter to the PayPal providers
+
 v3.0.1
 ------
 


### PR DESCRIPTION
Hello,

in our integration with `django-payments`, we started to use PayPal refunds. Unfortunately, this has broken our previous expectations on the content of `BasePayment.extra_data`. Our code expects that `payment.extra_data["response"]` is the response from the `PaypalProvider.process_data` call (forever). However, calls to `PaypalProvider.refund` overwrite this with their response.

This is an attempt to solve this issue by providing a possibility to store refund responses under a different key in `payment.extra_data` while preserving the original behavior by default for backward compatibility. The new approach was inspired by a similar (not configurable) behavior of `PaypalProvider.get_access_token` which stores its responses under `payment.extra_data["auth_response"]`.

This is also an attempt to fix the situation upstream although I have no idea how useful this might be for other `django-payments` users. If it turns out not being usable upstream I'd have to come up with a way to reliably customize `PaypalProvider` to our needs downstream (considering `PaypalProvider` has no public API except its constructor and https://django-payments.readthedocs.io/en/latest/backends.html#create-a-provider-class AFAIK).

It is also worth noting that `PaypalProvider.refund` is not the only method that overwrites `payment.extra_data["response"]`. But I did not want to overengineer this and since we do not use the other methods, this is enough for us so far. But I can take a look at the rest as well if needed.

I'd be happy for any feedback/opinion. Feel free to request any necessary changes 🙏