### PR TITLE
Add BlockBee to community providers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,3 +41,4 @@ Additional payment providers
 * `Redsys (formerly known as Sermepa) <https://github.com/ajostergaard/django-payments-redsys>`_
 * `Razorpay <https://github.com/NyanKiyoshi/django-payments-razorpay/>`_
 * `PayU <https://github.com/PetrDlouhy/django-payments-payu/>`_
+* `BlockBee <https://github.com/blockbee-io/django-payments-blockbee/>`_

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -295,6 +295,9 @@ These are the community providers compatible with ``django-payments``
   * - Common providers from Chile
     - CL
     - `mariofix/django-payments-chile <https://github.com/mariofix/django-payments-chile>`_
+  * - `BlockBee <https://www.blockbee.io/>`_
+    - Worldwide
+    - `blockbee-io/django-payments-blockbee <https://github.com/blockbee-io/django-payments-blockbee>`_
 
 
 Creating a New Provider Backend


### PR DESCRIPTION
We’ve developed a community provider for [BlockBee](https://blockbee.io) and would like to contribute it to the documentation. You can find it here: [django-payments-blockbee](https://github.com/blockbee-io/django-payments-blockbee).

Please let us know if you have any questions or if any adjustments are needed.