### PR TITLE
save payment object after transaction id and status is updated

### DIFF
--- a/payments/paypal/__init__.py
+++ b/payments/paypal/__init__.py
@@ -232,6 +232,7 @@ class PaypalProvider(BasicProvider):
             links = self._get_links(payment)
             redirect_to = links["approval_url"]
         payment.change_status(PaymentStatus.WAITING)
+        payment.save()
         raise RedirectNeeded(redirect_to["href"])
 
     def process_data(self, payment, request):


### PR DESCRIPTION
The paypal payment object is not getting saved after it is updated causing the transaction id (at the very least) to get lost.