### PR TITLE
Add Solana Payments backend to community providers documentation

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -298,6 +298,9 @@ These are the community providers compatible with ``django-payments``
   * - `BlockBee <https://www.blockbee.io/>`_
     - Worldwide
     - `blockbee-io/django-payments-blockbee <https://github.com/blockbee-io/django-payments-blockbee>`_
+  * - `Solana Payments (self-hosted) <https://django-solana-payments.readthedocs.io/en/latest/django_payments_integration.html>`_
+    - Worldwide
+    - `Artemooon/django-solana-payments <https://github.com/Artemooon/django-solana-payments>`_
 
 
 Creating a New Provider Backend


### PR DESCRIPTION
Hi, I have added a documentation entry for my library in community providers. It has a custom payment provider logic that is integrated with the django-payments and might be useful for anyone looking to create their own payment page using Solana.

Let me know if you have any questions