### PR TITLE
Add PaypalPPCPProvider - modern PayPal provider with recurring payments (Orders v2 + Vault)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ releases, in reverse chronological order.
 Unreleased
 ----------
 
+- Added ``payments.paypal.ppcp.PaypalPPCPProvider`` — modern PayPal
+  provider built on the Orders API v2 (PayPal has deprecated the v1
+  Payments API used by ``PaypalProvider``). Supports the redirect
+  checkout flow with synchronous capture, refunds via the Payments v2
+  API, idempotent API calls (``PayPal-Request-Id``), and — with
+  ``vault=True`` — the wallet interface: payment methods are vaulted on
+  checkout and later charged server-side (merchant-initiated
+  transactions).
+
 - Added the wallet interface for server-initiated recurring payments
   (merchant-initiated transactions with stored payment methods):
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,24 @@ Changelog
 This file contains a brief summary of new features and dependency changes or
 releases, in reverse chronological order.
 
+Unreleased
+----------
+
+- Added the wallet interface for server-initiated recurring payments
+  (merchant-initiated transactions with stored payment methods):
+
+  * ``BasePayment`` hooks: ``autocomplete_with_wallet()``,
+    ``get_renew_token()`` / ``get_renew_data()`` / ``set_renew_token()``
+  * ``BasicProvider.autocomplete_with_wallet()`` and
+    ``BasicProvider.erase_wallet(token)`` provider contract
+  * ``BaseWallet`` optional abstract model with a
+    PENDING/ACTIVE/ERASED lifecycle (``WalletStatus``)
+  * reference implementation in ``DummyProvider``; see ``docs/wallet.rst``
+
+  All additions are backward compatible: defaults are no-ops and existing
+  providers keep working unchanged. Implemented by ``django-payments-payu``
+  and the upcoming PayPal Complete Payments provider; Stripe support in #467.
+
 v4.0.0
 ------
 

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -140,6 +140,71 @@ Example::
 PayPal
 ------
 
+.. autoclass:: payments.paypal.ppcp.PaypalPPCPProvider
+
+Example::
+
+      PAYMENT_VARIANTS = {
+          'paypal': (
+              'payments.paypal.ppcp.PaypalPPCPProvider',
+              {
+                  'client_id': 'AeA1QIZXiflr...',
+                  'secret': 'EBLtcaBGXhXHR...',
+                  # sandbox; for production use https://api-m.paypal.com
+                  'endpoint': 'https://api-m.sandbox.paypal.com',
+              }
+          ),
+          # Wallet-capable variant: vaults the payment method on checkout
+          # and enables server-initiated renewals (see the wallet docs).
+          'paypal-recurring': (
+              'payments.paypal.ppcp.PaypalPPCPProvider',
+              {
+                  'client_id': 'AeA1QIZXiflr...',
+                  'secret': 'EBLtcaBGXhXHR...',
+                  'endpoint': 'https://api-m.sandbox.paypal.com',
+                  'vault': True,
+              }
+          ),
+      }
+
+Migrating from ``PaypalProvider``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The integrator-facing flow is unchanged: ``payment.get_form()`` raises
+``RedirectNeeded`` to PayPal's approval page, the buyer returns to the
+process URL, and the payment ends up ``CONFIRMED``/``REJECTED``;
+``payment.refund()`` keeps working. The same REST application
+credentials (``client_id``/``secret``) work for both providers, so no
+new PayPal onboarding is needed.
+
+Differences to check before switching:
+
+* **Pre-authorization is not supported yet** — ``capture=False``
+  raises ``NotImplementedError`` at configuration time (the legacy
+  provider authorizes in this mode). Keep using ``PaypalProvider`` for
+  preauth flows for now.
+* **Direct card payments** (``PaypalCardProvider``) have no PPCP
+  equivalent yet (PayPal's Advanced Card Payments are not implemented).
+* **transaction_id semantics changed**: the legacy provider stores the
+  v1 payment id (``PAY-…``) at order creation; this provider stores the
+  *capture* id, set only once the payment is captured.
+* **extra_data layout changed**: raw API responses are stored under
+  ``ppcp_order``/``ppcp_capture``/``ppcp_refund`` instead of the legacy
+  ``response``/``links`` keys. Code that parses ``extra_data`` directly
+  (e.g. fee extraction) must read the new keys — the PayPal fee is at
+  ``ppcp_capture.purchase_units[0].payments.captures[0]
+  .seller_receivable_breakdown.paypal_fee``.
+* **Endpoint host**: use ``https://api-m.paypal.com`` (or
+  ``https://api-m.sandbox.paypal.com``).
+
+Migrate by adding a *new* variant name for this provider and keeping
+the legacy variant configured until payments created under it are
+finished — a payment must be processed by the provider that created it.
+
+The providers below use PayPal's v1 Payments API, which PayPal has
+deprecated; they remain for existing integrations. New integrations
+should use :class:`~payments.paypal.ppcp.PaypalPPCPProvider` above.
+
 .. autoclass:: payments.paypal.PaypalProvider
 
 Example::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ Contents:
    usage.rst
    refund.rst
    preauth.rst
+   wallet.rst
    webhooks.rst
    api.rst
    changelog.rst

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -100,3 +100,10 @@ fraud status of your payment by accessing ``payment.fraud_status`` and
 
 ``review``
       The payment was marked for review.
+
+Recurring payments
+------------------
+
+For server-initiated recurring payments (subscriptions, auto-renewals), see
+:doc:`wallet`. The wallet interface allows you to store payment methods and
+charge them without user interaction.

--- a/docs/wallet.rst
+++ b/docs/wallet.rst
@@ -221,9 +221,9 @@ Known implementations
 * `django-payments-payu <https://github.com/PetrDlouhy/django-payments-payu>`_
   (released) — card tokens, raises ``RedirectNeeded`` for CVV/3-D Secure
   re-verification during renewals.
-* PayPal Complete Payments (Orders v2 + Vault) — vault payment tokens,
-  merchant-initiated renewal charges; in production at
-  `Blendkit <https://www.blendkit.com>`_, upstream PR planned.
+* :class:`~payments.paypal.ppcp.PaypalPPCPProvider` (this repository) —
+  vault payment tokens, merchant-initiated renewal charges; the same flow
+  runs in production at `Blendkit <https://www.blendkit.com>`_.
 * Stripe (`#467 <https://github.com/jazzband/django-payments/pull/467>`_)
   — PaymentMethod + Customer via ``get_renew_data()``, ``off_session``
   PaymentIntents.

--- a/docs/wallet.rst
+++ b/docs/wallet.rst
@@ -1,0 +1,231 @@
+Recurring payments with stored payment methods (wallets)
+========================================================
+
+What is a wallet?
+-----------------
+
+A *wallet* is a stored, chargeable payment method: after one successful
+checkout in which the user consents to future charges, the provider hands
+back a token (a card token at PayU, a vault payment token at PayPal, a
+PaymentMethod id at Stripe) that lets the merchant charge that user again
+**server-side, without any user interaction**. The industry calls these
+charges *merchant-initiated transactions* ("card on file").
+
+This enables subscription renewals, usage-based billing, installments and
+similar flows where **your application decides when and how much to
+charge** — the amount is taken from ``payment.total`` and can differ on
+every charge.
+
+This is deliberately *not* the provider-managed subscription model (where
+the provider charges a fixed amount on a fixed schedule and notifies you
+afterwards). Provider-managed subscriptions are out of scope for this
+interface.
+
+The interface has two layers:
+
+1. **The contract** (required): a small set of methods on
+   :class:`~payments.core.BasicProvider` and hooks on
+   :class:`~payments.models.BasePayment` that every wallet-capable
+   provider and every integrating application share.
+2. **BaseWallet** (optional): a ready-made abstract model implementing
+   the storage half of the contract. Use it for new projects; skip it if
+   your application already has its own token storage (for example
+   `django-plans-payments <https://github.com/PetrDlouhy/django-plans-payments>`_
+   stores tokens on its ``RecurringUserPlan``).
+
+Flow
+----
+
+.. code-block:: text
+
+    First Payment (Setup):
+    ┌─────────────┐
+    │ User enters │
+    │ card details│
+    └──────┬──────┘
+           │
+           ▼
+    ┌─────────────────┐
+    │ Provider stores │
+    │ payment method  │
+    └──────┬──────────┘
+           │
+           ▼
+    ┌──────────────────┐
+    │ set_renew_token()│ ← Store token in wallet
+    │ wallet.activate()│
+    └──────────────────┘
+
+    Recurring Charge (Server-Initiated, any amount):
+    ┌─────────────────┐
+    │ Your server     │
+    │ creates Payment │
+    │ with any amount │
+    └──────┬──────────┘
+           │
+           ▼
+    ┌──────────────────────┐
+    │ payment.             │
+    │ autocomplete_with_   │
+    │ wallet()             │
+    └──────┬───────────────┘
+           │
+           ▼
+    ┌──────────────────────┐
+    │ get_renew_token()    │ ← Retrieve token from wallet
+    └──────┬───────────────┘
+           │
+           ▼
+    ┌──────────────────────┐
+    │ Provider charges     │
+    │ stored payment method│
+    └──────┬───────────────┘
+           │
+           ▼
+    ┌──────────────────────┐
+    │ Update payment status│
+    │ wallet.payment_      │
+    │ completed()          │
+    └──────────────────────┘
+
+Layer 1: the contract
+---------------------
+
+Provider side (``BasicProvider``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``autocomplete_with_wallet(payment)``
+    Charge the stored payment method server-side for ``payment.total``.
+    On success, update the payment status and call
+    ``self._finalize_wallet_payment(payment)`` (which triggers
+    ``wallet.payment_completed()`` for wallet-model users). If the
+    provider requires user interaction to complete the charge (3-D
+    Secure, CVV confirmation), raise
+    :class:`~payments.RedirectNeeded` with the URL where the user can
+    finish the payment — callers are expected to handle it (e.g. by
+    emailing the user a link). On a decline, set the payment status to
+    ``REJECTED``/``ERROR``.
+
+``erase_wallet(token)``
+    Revoke the stored payment method at the provider (delete the card
+    token, vault token or detach the payment method). After this, no
+    further charges are possible.
+
+During the *first* payment, a wallet-capable provider requests
+tokenization from the gateway and, once granted, stores the token via
+``payment.set_renew_token(token, **metadata)``. The metadata keyword
+arguments are provider-specific (card expiry and masked number for card
+providers, ``customer_id`` for Stripe, nothing for PayPal) — integrators
+should accept ``**kwargs``.
+
+Integrator side (``BasePayment`` hooks)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``autocomplete_with_wallet()``
+    Entry point for your billing code: dispatches to the provider for
+    this payment's variant. Performs **no authorization checks** — the
+    caller must verify ownership and amounts.
+
+``get_renew_token()`` / ``get_renew_data()``
+    Return the stored token (or a dict with the token plus
+    provider-specific extras, e.g. ``customer_id``). Return ``None``
+    when there is nothing chargeable — in particular, only return tokens
+    from *active* wallets, never pending or erased ones.
+
+``set_renew_token(token, **metadata)``
+    Store the token wherever your application keeps it (a wallet model,
+    a subscription model of your own, ``extra_data``, …).
+
+``get_payment_url()``
+    URL of your application's view for this payment. Providers use it as
+    the ``RedirectNeeded`` target when a server-initiated charge requires
+    user interaction after all (e.g. PayU's CVV / 3-D Secure
+    re-verification). Only needed with such providers.
+
+The default implementations return ``None``/do nothing, so a payment
+model without recurring support keeps working unchanged.
+
+Layer 2: BaseWallet (optional storage)
+--------------------------------------
+
+:class:`~payments.models.BaseWallet` is an abstract model providing the
+storage half of the contract: a ``token``, provider-specific
+``extra_data`` (JSON), and a lifecycle ``status``:
+
+``PENDING → ACTIVE → ERASED``
+
+The token is not chargeable until the first payment succeeds
+(``payment_completed()`` activates a pending wallet), and never again
+after erasure. Every known integration reinvented exactly this
+lifecycle, which is why it is part of the interface.
+
+.. code-block:: python
+
+    from payments.models import BasePayment, BaseWallet
+
+    class Wallet(BaseWallet):
+        user = models.ForeignKey(User, on_delete=models.CASCADE)
+        payment_provider = models.CharField(max_length=50)
+
+    class Payment(BasePayment):
+        wallet = models.ForeignKey(
+            Wallet, null=True, blank=True, on_delete=models.SET_NULL
+        )
+
+        def get_renew_token(self):
+            if self.wallet and self.wallet.status == WalletStatus.ACTIVE:
+                return self.wallet.token
+            return None
+
+        def set_renew_token(self, token, **metadata):
+            if not self.wallet:
+                self.wallet = Wallet.objects.create(
+                    user=self.user, payment_provider=self.variant
+                )
+                self.save(update_fields=["wallet"])
+            self.wallet.token = token
+            self.wallet.extra_data.update(metadata)
+            self.wallet.save(update_fields=["token", "extra_data"])
+            self.wallet.activate()
+
+To cancel recurring payments, revoke at the provider first, then mark
+the wallet erased:
+
+.. code-block:: python
+
+    provider = provider_factory(wallet.payment_provider)
+    provider.erase_wallet(wallet.token)
+    wallet.erase()
+
+Charging a stored method
+------------------------
+
+.. code-block:: python
+
+    payment = Payment.objects.create(
+        variant="payu-recurring",   # a wallet-capable variant
+        total=Decimal("14.99"),     # any amount - can differ every cycle
+        currency="USD",
+        ...,
+    )
+    try:
+        payment.autocomplete_with_wallet()
+    except RedirectNeeded as redirect_to:
+        # user interaction required (3-D Secure / CVV) -
+        # e.g. email the user a link to str(redirect_to)
+        ...
+
+Known implementations
+---------------------
+
+* `django-payments-payu <https://github.com/PetrDlouhy/django-payments-payu>`_
+  (released) — card tokens, raises ``RedirectNeeded`` for CVV/3-D Secure
+  re-verification during renewals.
+* PayPal Complete Payments (Orders v2 + Vault) — vault payment tokens,
+  merchant-initiated renewal charges; in production at
+  `Blendkit <https://www.blendkit.com>`_, upstream PR planned.
+* Stripe (`#467 <https://github.com/jazzband/django-payments/pull/467>`_)
+  — PaymentMethod + Customer via ``get_renew_data()``, ``off_session``
+  PaymentIntents.
+* ``DummyProvider`` in this repository — reference implementation for
+  tests.

--- a/payments/__init__.py
+++ b/payments/__init__.py
@@ -63,6 +63,18 @@ class FraudStatus:
     ]
 
 
+class WalletStatus:
+    PENDING = "pending"
+    ACTIVE = "active"
+    ERASED = "erased"
+
+    CHOICES = [
+        (PENDING, pgettext_lazy("wallet status", "Pending")),
+        (ACTIVE, pgettext_lazy("wallet status", "Active")),
+        (ERASED, pgettext_lazy("wallet status", "Erased")),
+    ]
+
+
 class RedirectNeeded(Exception):
     pass
 

--- a/payments/core.py
+++ b/payments/core.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
+
 if TYPE_CHECKING:
     from django.http import HttpRequest
 
@@ -142,6 +143,70 @@ class BasicProvider:
             qs = urlencode(extra_data)
             return url + "?" + qs
         return url
+
+    def autocomplete_with_wallet(self, payment):
+        """
+        Complete the payment with wallet (server-initiated charge).
+
+        This method charges a stored payment method without user interaction.
+        The amount to charge is taken from payment.total and can vary with each call.
+
+        Provider implementation should:
+        1. Retrieve the payment method token from payment.get_renew_token()
+        2. Create a charge with the payment provider's API using payment.total
+        3. Update payment status accordingly
+        4. Call self._finalize_wallet_payment(payment) on success
+
+        If user interaction is required (e.g., 3D Secure), raise RedirectNeeded
+        with the URL where the user should be redirected.
+
+        Args:
+            payment: BasePayment instance to charge (amount from payment.total)
+
+        Raises:
+            RedirectNeeded: If user interaction required (3DS, CVV, etc.)
+            PaymentError: If payment fails or no token found
+        """
+        raise NotImplementedError
+
+    def _finalize_wallet_payment(self, payment, wallet=None):
+        """
+        Internal helper to finalize wallet payment.
+
+        Should be called by providers after successful wallet payment.
+        Triggers payment_completed hook on the wallet if available.
+
+        Args:
+            payment: BasePayment instance that was charged
+            wallet: Optional wallet instance (will try to get from payment if not
+                provided)
+        """
+        if wallet is None and hasattr(payment, "wallet"):
+            wallet = payment.wallet
+
+        if wallet is not None:
+            wallet.payment_completed(payment)
+
+    def erase_wallet(self, token):
+        """
+        Revoke a stored payment method at the provider.
+
+        Providers should override this to delete/detach the stored payment
+        method identified by ``token`` from their system (e.g. delete the
+        card token at PayU, delete the vault payment token at PayPal, detach
+        the PaymentMethod at Stripe). The default implementation does
+        nothing, for providers where tokens cannot or need not be revoked.
+
+        Integrators using a wallet model should revoke at the provider first
+        and then mark the wallet erased::
+
+            provider = provider_factory(wallet.payment_provider)
+            provider.erase_wallet(wallet.token)
+            wallet.erase()
+
+        Args:
+            token: The stored payment method token/id to revoke
+        """
 
     def capture(self, payment, amount=None):
         raise NotImplementedError

--- a/payments/core.py
+++ b/payments/core.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
-
 if TYPE_CHECKING:
     from django.http import HttpRequest
 

--- a/payments/dummy/__init__.py
+++ b/payments/dummy/__init__.py
@@ -66,6 +66,32 @@ class DummyProvider(BasicProvider):
             return HttpResponseRedirect(payment.get_success_url())
         return HttpResponseRedirect(payment.get_failure_url())
 
+    def autocomplete_with_wallet(self, payment):
+        """
+        Dummy implementation of wallet-based recurring payment.
+
+        This demonstrates the expected flow for wallet-based providers:
+        1. Get token from payment.get_renew_token()
+        2. Simulate charging with the stored payment method
+        3. Update payment status
+        4. Call _finalize_wallet_payment on success
+
+        Note: Real providers should validate wallet status before charging.
+        DummyProvider is lenient for testing purposes.
+        """
+        renew_token = payment.get_renew_token()
+        if not renew_token:
+            raise PaymentError("No payment method token found for recurring payment")
+
+        # Simulate successful charge
+        payment.transaction_id = f"dummy-wallet-charge-{payment.token}"
+        payment.captured_amount = payment.total
+        payment.change_status(PaymentStatus.CONFIRMED)
+        payment.save(update_fields=["transaction_id", "captured_amount"])
+
+        # Finalize wallet payment (triggers wallet.payment_completed)
+        self._finalize_wallet_payment(payment)
+
     def capture(self, payment, amount=None):
         payment.change_status(PaymentStatus.CONFIRMED)
         payment.captured_amount = amount or payment.total

--- a/payments/models.py
+++ b/payments/models.py
@@ -17,6 +17,7 @@ from phonenumber_field.modelfields import PhoneNumberField
 from . import FraudStatus
 from . import PaymentStatus
 from . import PurchasedItem
+from . import WalletStatus
 from .core import provider_factory
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,83 @@ class PaymentAttributeProxy:
         data[key] = value
         self._payment.extra_data = json.dumps(data)
         return None
+
+
+class BaseWallet(models.Model):
+    """
+    Abstract model for storing payment method tokens for recurring payments.
+
+    This model provides a base structure for wallet-based payment providers
+    (PayU, Stripe, Adyen, etc.) that support server-initiated recurring payments.
+
+    Typical usage:
+        1. Create wallet when user enrolls in recurring payments
+        2. After first successful payment, provider stores token and activates wallet
+        3. For recurring charges, retrieve token and charge through provider
+        4. When user cancels, erase wallet through provider.erase_wallet()
+
+    Example implementation:
+        class Wallet(BaseWallet):
+            user = models.ForeignKey(User, on_delete=models.CASCADE)
+            payment_provider = models.CharField(max_length=50)
+
+            def payment_completed(self, payment):
+                # Custom logic after successful payment
+                if payment.status == PaymentStatus.CONFIRMED:
+                    self.activate()
+                    self.user.send_notification("Payment successful")
+    """
+
+    token = models.CharField(
+        _("wallet token/id"),
+        help_text=_(
+            "Payment method token/ID from provider (e.g., PaymentMethod ID for Stripe, "
+            "card token for PayU, recurringDetailReference for Adyen)"
+        ),
+        max_length=255,
+        default="",
+        blank=True,
+    )
+    status = models.CharField(
+        max_length=10, choices=WalletStatus.CHOICES, default=WalletStatus.PENDING
+    )
+    extra_data = models.JSONField(
+        _("extra data"),
+        help_text=_(
+            "Provider-specific data (e.g., card details, expiry dates, customer IDs)"
+        ),
+        default=dict,
+    )
+
+    class Meta:
+        abstract = True
+
+    def payment_completed(self, payment):
+        """
+        Called after a payment using this wallet is completed successfully.
+
+        Default implementation activates the wallet on first successful payment.
+        Override in subclass for custom behavior (notifications, logging, etc.).
+
+        Args:
+            payment: The BasePayment instance that was completed
+        """
+        if (
+            payment.status == PaymentStatus.CONFIRMED
+            and self.status == WalletStatus.PENDING
+        ):
+            self.status = WalletStatus.ACTIVE
+            self.save(update_fields=["status"])
+
+    def activate(self):
+        """Mark wallet as active and ready for recurring charges."""
+        self.status = WalletStatus.ACTIVE
+        self.save(update_fields=["status"])
+
+    def erase(self):
+        """Mark wallet as erased (no longer usable)."""
+        self.status = WalletStatus.ERASED
+        self.save(update_fields=["status"])
 
 
 class BasePayment(models.Model):
@@ -196,6 +274,107 @@ class BasePayment(models.Model):
 
     def get_process_url(self) -> str:
         return reverse("process_payment", kwargs={"token": self.token})
+
+    def get_payment_url(self) -> str:
+        """URL of the application view that displays this payment.
+
+        Wallet-capable providers use it as the destination for
+        :class:`~payments.RedirectNeeded` when a server-initiated charge
+        turns out to require user interaction after all (e.g. the PayU
+        provider sends users here to re-enter CVV / pass 3-D Secure).
+
+        Only needs to be implemented when such a provider is used.
+        """
+        raise NotImplementedError
+
+    def autocomplete_with_wallet(self):
+        """
+        Complete the payment with wallet (server-initiated charge).
+
+        This method charges a stored payment method without user interaction.
+        The amount is taken from payment.total - it can vary with each charge.
+
+        Use cases:
+        - Subscription renewals (fixed or variable amounts)
+        - Usage-based billing (charges based on consumption)
+        - Flexible billing (proration, credits, discounts)
+        - Multi-charge workflows (deposits, installments)
+
+        Security: This method performs NO authorization checks. The caller must:
+        - Verify user ownership of payment/wallet before calling
+        - Implement rate limiting to prevent abuse
+        - Validate payment amount and currency
+
+        Raises:
+            RedirectNeeded: If user interaction required (3D Secure, CVV, etc.)
+            PaymentError: If payment fails or no token found
+        """
+        provider = provider_factory(self.variant)
+        provider.autocomplete_with_wallet(self)
+
+    def get_renew_token(self):
+        """
+        Get stored payment method token for recurring payments.
+
+        Default implementation returns None. Subclasses should override this method
+        to return the token from their storage mechanism (e.g., from a related
+        wallet model, RecurringUserPlan model, or extra_data field).
+
+        Security: Only return token if wallet status is ACTIVE. Never return
+        tokens from PENDING or ERASED wallets.
+
+        For simple use cases with wallet support, this can be implemented as:
+            if self.wallet and self.wallet.status == WalletStatus.ACTIVE:
+                return self.wallet.token
+            return None
+
+        Returns:
+            str or None: Payment method token/ID for recurring charges
+        """
+        return
+
+    def get_renew_data(self):
+        """
+        Get all data needed for recurring payment charge.
+
+        Default implementation returns token only (backward compatible with
+        get_renew_token). Override to return provider-specific data
+        (customer_id, etc.).
+
+        Example override for providers requiring additional data:
+            def get_renew_data(self):
+                token = self.wallet.token
+                if not token:
+                    return None
+                return {
+                    "token": token,
+                    "customer_id": self.wallet.extra_data.get("stripe_customer_id"),
+                }
+
+        Returns:
+            dict or None: Payment data with at minimum {"token": "xxx"},
+                or None if no data
+        """
+        token = self.get_renew_token()
+        return {"token": token} if token else None
+
+    def set_renew_token(self, token, **kwargs):
+        """
+        Store payment method token for future recurring payments.
+
+        Default implementation does nothing. Subclasses should override this method
+        to store the token in their storage mechanism (e.g., in a related wallet
+        model, RecurringUserPlan model, or extra_data field).
+
+        Providers pass provider-specific metadata as keyword arguments;
+        overrides should therefore always accept ``**kwargs``. Common keys:
+        ``card_expire_year``, ``card_expire_month``, ``card_masked_number``
+        (card providers), ``customer_id`` (Stripe), ``automatic_renewal``.
+
+        Args:
+            token: Payment method token/ID from the provider
+            **kwargs: Provider-specific metadata (see above)
+        """
 
     def capture(self, amount=None) -> None:
         """Capture a pre-authorized payment.

--- a/payments/paypal/ppcp.py
+++ b/payments/paypal/ppcp.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import TYPE_CHECKING
+from urllib.parse import urljoin
+
+import requests
+from django.shortcuts import redirect
+
+from payments import PaymentError
+from payments import PaymentStatus
+from payments import RedirectNeeded
+from payments.core import BasicProvider
+from payments.core import get_base_url
+
+if TYPE_CHECKING:
+    from decimal import Decimal
+
+logger = logging.getLogger(__name__)
+
+TOKEN_EXPIRY_SAFETY_MARGIN_SECONDS = 60
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+class PaypalPPCPProvider(BasicProvider):
+    """PayPal Complete Payments provider (Orders API v2 + Vault).
+
+    This is the modern PayPal provider: PayPal has deprecated the v1
+    Payments API used by :class:`~payments.paypal.PaypalProvider`, and new
+    integrations should use this provider instead.
+
+    Checkout uses the redirect (approval-link) flow: an order is created
+    via the Orders v2 API, the user approves it on PayPal's page, and the
+    payment is captured synchronously when they return.
+
+    With ``vault=True`` the provider implements the wallet interface (see
+    :doc:`/wallet`): the user's consent to future charges is requested
+    during checkout (``store_in_vault``), the resulting vault payment token
+    is handed to ``payment.set_renew_token()``, and later payments can be
+    charged server-side through ``autocomplete_with_wallet()`` without any
+    user interaction (merchant-initiated transactions).
+
+    :param client_id: Client ID of your PayPal REST application
+    :param secret: Secret of your PayPal REST application
+    :param endpoint: The API endpoint to use. For the sandbox environment,
+        use ``'https://api-m.sandbox.paypal.com'``
+    :param capture: Whether to capture the payment automatically
+    :param vault: Store the payment method on successful checkout and
+        enable server-initiated recurring charges (the wallet interface)
+    :param brand_name: Merchant name shown on the PayPal review page
+    """
+
+    def __init__(
+        self,
+        client_id: str,
+        secret: str,
+        endpoint: str = "https://api-m.paypal.com",
+        capture: bool = True,
+        vault: bool = False,
+        brand_name: str = "",
+    ) -> None:
+        if not capture:
+            # The legacy PaypalProvider authorizes with capture=False; this
+            # provider only implements intent=CAPTURE so far. Fail at
+            # configuration time rather than silently capturing.
+            raise NotImplementedError(
+                "PaypalPPCPProvider does not support pre-authorization "
+                "(capture=False) yet"
+            )
+        self.client_id = client_id
+        self.secret = secret
+        self.endpoint = endpoint
+        self.vault = vault
+        self.brand_name = brand_name
+        self.oauth2_url = endpoint + "/v1/oauth2/token"
+        self.orders_url = endpoint + "/v2/checkout/orders"
+        self.captures_url = endpoint + "/v2/payments/captures"
+        self.vault_tokens_url = endpoint + "/v3/vault/payment-tokens"
+        self._access_token: str | None = None
+        self._access_token_expires_at = 0.0
+        super().__init__(capture=capture)
+
+    # -- HTTP layer --------------------------------------------------------
+
+    def get_access_token(self) -> str:
+        """Return a cached OAuth2 access token, fetching a new one if needed."""
+        now = time.monotonic()
+        if (
+            self._access_token
+            and now < self._access_token_expires_at - TOKEN_EXPIRY_SAFETY_MARGIN_SECONDS
+        ):
+            return self._access_token
+        response = requests.post(
+            self.oauth2_url,
+            data={"grant_type": "client_credentials"},
+            auth=(self.client_id, self.secret),
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        data = response.json()
+        self._access_token = "{} {}".format(data["token_type"], data["access_token"])
+        self._access_token_expires_at = now + data.get("expires_in", 300)
+        return self._access_token
+
+    def api_post(self, url, json_body=None, request_id=None) -> dict:
+        """Perform an authorized POST request to the PayPal API.
+
+        :param url: full API URL to post to
+        :param json_body: JSON-serializable request body
+        :param request_id: value for the ``PayPal-Request-Id`` idempotency
+            header; a retried call (timeout, double click on the return URL)
+            then replays the original result instead of double-charging
+        :returns: JSON response data from the PayPal API
+        :raises requests.HTTPError: if the API returns an error status code
+        """
+        headers = {
+            "Authorization": self.get_access_token(),
+            "Content-Type": "application/json",
+        }
+        if request_id:
+            headers["PayPal-Request-Id"] = request_id
+        response = requests.post(
+            url,
+            json=json_body if json_body is not None else {},
+            headers=headers,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        if not response.ok:
+            logger.warning(
+                "PayPal PPCP API error: url=%s status=%s body=%s",
+                url,
+                response.status_code,
+                response.text[:2000],
+            )
+        response.raise_for_status()
+        return response.json()
+
+    # -- payment extra_data helpers ----------------------------------------
+
+    @staticmethod
+    def _get_attr(payment, key):
+        extra_data = json.loads(payment.extra_data or "{}")
+        return extra_data.get(key)
+
+    @staticmethod
+    def _set_attr(payment, key, value) -> None:
+        extra_data = json.loads(payment.extra_data or "{}")
+        extra_data[key] = value
+        payment.extra_data = json.dumps(extra_data)
+
+    # -- checkout flow -----------------------------------------------------
+
+    def get_form(self, payment, data=None):
+        """Create the PayPal order and redirect the buyer to approve it."""
+        if not payment.id:
+            payment.save()
+        order_data = self._get_attr(payment, "ppcp_order")
+        if not order_data:
+            order_data = self.create_order(payment)
+            self._set_attr(payment, "ppcp_order", order_data)
+            payment.save()
+        approve_url = self._get_link(order_data, ("payer-action", "approve"))
+        if not approve_url:
+            raise PaymentError(
+                f"PayPal order {order_data.get('id')} has no approval link"
+            )
+        payment.change_status(PaymentStatus.WAITING)
+        raise RedirectNeeded(approve_url)
+
+    def create_order(self, payment) -> dict:
+        """Create an Orders v2 order for this payment."""
+        experience_context = {
+            "return_url": self.get_return_url(payment),
+            "cancel_url": urljoin(get_base_url(), payment.get_failure_url()),
+            "user_action": "PAY_NOW",
+            "shipping_preference": "NO_SHIPPING",
+        }
+        if self.brand_name:
+            experience_context["brand_name"] = self.brand_name
+        paypal_source: dict = {"experience_context": experience_context}
+        if self.vault:
+            paypal_source["attributes"] = {
+                "vault": {
+                    "store_in_vault": "ON_SUCCESS",
+                    "usage_type": "MERCHANT",
+                    "customer_type": "CONSUMER",
+                }
+            }
+        body = {
+            "intent": "CAPTURE",
+            "purchase_units": [self.get_purchase_unit(payment)],
+            "payment_source": {"paypal": paypal_source},
+        }
+        return self.api_post(
+            self.orders_url, body, request_id=f"create-{payment.token}"
+        )
+
+    def get_purchase_unit(self, payment) -> dict:
+        return {
+            "amount": {
+                "currency_code": payment.currency,
+                "value": str(payment.total),
+            },
+            "description": (payment.description or "")[:127],
+            "custom_id": str(payment.pk),
+        }
+
+    @staticmethod
+    def _get_link(order_data, rels):
+        for link in order_data.get("links", []):
+            if link.get("rel") in rels:
+                return link.get("href")
+        return None
+
+    def process_data(self, payment, request):
+        """Handle the buyer returning from PayPal: capture the order."""
+        if payment.status == PaymentStatus.CONFIRMED:
+            # Buyer reloaded the return URL of an already-captured payment.
+            return redirect(payment.get_success_url())
+
+        order_data = self._get_attr(payment, "ppcp_order") or {}
+        order_id = order_data.get("id")
+        returned_order_id = request.GET.get("token")
+        if not order_id or returned_order_id != order_id:
+            raise PaymentError(
+                f"PayPal return does not match payment: "
+                f"expected order {order_id}, got {returned_order_id}"
+            )
+        if not request.GET.get("PayerID"):
+            # Buyer landed on the return URL without approving the order.
+            payment.change_status(PaymentStatus.REJECTED, "Buyer did not approve")
+            return redirect(payment.get_failure_url())
+
+        capture_data = self.api_post(
+            f"{self.orders_url}/{order_id}/capture",
+            request_id=f"capture-{payment.token}",
+        )
+        self._set_attr(payment, "ppcp_capture", capture_data)
+        return self._apply_capture_result(payment, capture_data)
+
+    def _apply_capture_result(self, payment, capture_data):
+        # change_status() persists ONLY status+message (update_fields), so
+        # every bookkeeping field must be saved explicitly before calling it.
+        if capture_data.get("status") != "COMPLETED":
+            payment.save()
+            payment.change_status(
+                PaymentStatus.REJECTED,
+                f"PayPal order status: {capture_data.get('status')}",
+            )
+            return redirect(payment.get_failure_url())
+
+        capture = self._extract_capture(capture_data)
+        payment.transaction_id = capture["id"]
+        payment.captured_amount = payment.total
+        payment.save()
+
+        vault_data = (
+            capture_data.get("payment_source", {})
+            .get("paypal", {})
+            .get("attributes", {})
+            .get("vault", {})
+        )
+        if self.vault and vault_data.get("id"):
+            payment.set_renew_token(vault_data["id"])
+
+        payment.change_status(PaymentStatus.CONFIRMED)
+        self._finalize_wallet_payment(payment)
+        return redirect(payment.get_success_url())
+
+    @staticmethod
+    def _extract_capture(capture_data) -> dict:
+        purchase_units = capture_data.get("purchase_units", [])
+        if purchase_units:
+            captures = purchase_units[0].get("payments", {}).get("captures", [])
+            if captures:
+                return captures[0]
+        raise PaymentError(
+            f"PayPal capture response has no capture object: "
+            f"order {capture_data.get('id')}"
+        )
+
+    # -- wallet interface (server-initiated recurring charges) -------------
+
+    def autocomplete_with_wallet(self, payment) -> None:
+        """Charge the vaulted PayPal payment token (merchant-initiated)."""
+        renew_token = payment.get_renew_token()
+        if not renew_token:
+            raise PaymentError(f"No PayPal vault token to renew payment {payment.pk}")
+        body = {
+            "intent": "CAPTURE",
+            "purchase_units": [self.get_purchase_unit(payment)],
+            "payment_source": {
+                "token": {"id": renew_token, "type": "PAYMENT_METHOD_TOKEN"}
+            },
+        }
+        try:
+            order_data = self.api_post(
+                self.orders_url, body, request_id=f"renew-{payment.token}"
+            )
+        except requests.HTTPError as e:
+            payment.change_status(PaymentStatus.ERROR, f"PayPal renewal failed: {e}")
+            return
+        self._set_attr(payment, "ppcp_order", order_data)
+        if order_data.get("status") != "COMPLETED":
+            # Some accounts return CREATED and need an explicit capture step.
+            order_data = self.api_post(
+                f"{self.orders_url}/{order_data['id']}/capture",
+                request_id=f"renew-capture-{payment.token}",
+            )
+        self._set_attr(payment, "ppcp_capture", order_data)
+        if order_data.get("status") != "COMPLETED":
+            payment.save()
+            payment.change_status(
+                PaymentStatus.REJECTED,
+                f"PayPal renewal order status: {order_data.get('status')}",
+            )
+            return
+        capture = self._extract_capture(order_data)
+        payment.transaction_id = capture["id"]
+        payment.captured_amount = payment.total
+        # Persist bookkeeping before change_status's partial save (see above).
+        payment.save()
+        payment.change_status(PaymentStatus.CONFIRMED)
+        self._finalize_wallet_payment(payment)
+
+    def erase_wallet(self, token) -> None:
+        """Delete the vaulted payment method (cancels future renewals).
+
+        A 404 means the token is already gone at PayPal and is treated as
+        success, so erasing twice stays idempotent.
+        """
+        response = requests.delete(
+            f"{self.vault_tokens_url}/{token}",
+            headers={"Authorization": self.get_access_token()},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        if response.status_code == 404:
+            logger.warning("PayPal vault token already deleted: %s", token)
+            return
+        response.raise_for_status()
+
+    # -- refunds -----------------------------------------------------------
+
+    def refund(self, payment, amount=None) -> Decimal:
+        if not payment.transaction_id:
+            raise PaymentError(f"Payment {payment.pk} has no PayPal capture to refund")
+        body = {}
+        if amount is not None:
+            body["amount"] = {
+                "currency_code": payment.currency,
+                "value": str(amount),
+            }
+        refund_data = self.api_post(
+            f"{self.captures_url}/{payment.transaction_id}/refund",
+            body,
+            request_id=f"refund-{payment.token}-{amount}",
+        )
+        self._set_attr(payment, "ppcp_refund", refund_data)
+        payment.save()
+        if refund_data.get("status") not in ("COMPLETED", "PENDING"):
+            raise PaymentError(
+                f"PayPal refund failed with status {refund_data.get('status')}"
+            )
+        return amount if amount is not None else payment.captured_amount

--- a/payments/paypal/test_ppcp.py
+++ b/payments/paypal/test_ppcp.py
@@ -1,0 +1,489 @@
+"""Unit tests for the PayPal PPCP provider (Orders v2 + Vault).
+
+HTTP layer is mocked; the payment object is a stub mirroring the
+django-payments BasePayment surface the provider touches, following the
+style of the provider tests in django-payments itself.
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+import requests
+from django.test import RequestFactory
+from django.test import TestCase
+from django.test import override_settings
+
+from payments import PaymentError
+from payments import PaymentStatus
+from payments import RedirectNeeded
+
+from .ppcp import PaypalPPCPProvider
+
+ORDER_ID = "5O190127TN364715T"
+CAPTURE_ID = "3C679366HH908993F"
+VAULT_ID = "8kk8451t"
+
+OAUTH_RESPONSE = {
+    "token_type": "Bearer",
+    "access_token": "A21AAFs",
+    "expires_in": 32400,
+}
+
+CREATE_ORDER_RESPONSE = {
+    "id": ORDER_ID,
+    "status": "PAYER_ACTION_REQUIRED",
+    "links": [
+        {
+            "href": "https://api-m.sandbox.paypal.com/v2/checkout/orders/" + ORDER_ID,
+            "rel": "self",
+            "method": "GET",
+        },
+        {
+            "href": "https://www.sandbox.paypal.com/checkoutnow?token=" + ORDER_ID,
+            "rel": "payer-action",
+            "method": "GET",
+        },
+    ],
+}
+
+
+def capture_response(status="COMPLETED", vault=None, fee="0.84"):
+    response = {
+        "id": ORDER_ID,
+        "status": status,
+        "purchase_units": [
+            {
+                "payments": {
+                    "captures": [
+                        {
+                            "id": CAPTURE_ID,
+                            "status": "COMPLETED",
+                            "amount": {"currency_code": "USD", "value": "14.31"},
+                            "seller_receivable_breakdown": {
+                                "paypal_fee": {
+                                    "currency_code": "USD",
+                                    "value": fee,
+                                },
+                            },
+                        }
+                    ]
+                }
+            }
+        ],
+    }
+    if vault:
+        response["payment_source"] = {
+            "paypal": {"attributes": {"vault": {"id": vault, "status": "VAULTED"}}}
+        }
+    return response
+
+
+PERSISTED_FIELDS = (
+    "status",
+    "message",
+    "transaction_id",
+    "captured_amount",
+    "extra_data",
+)
+
+
+class PaymentStub:
+    """Stub of the django-payments BasePayment surface used by the provider.
+
+    ``save``/``change_status`` mimic BasePayment's persistence semantics --
+    ``change_status`` saves with ``update_fields=["status", "message"]``, so
+    any other field the provider assigned but did not save explicitly is
+    LOST. ``persisted`` holds what would have reached the database.
+    """
+
+    def __init__(self):
+        self.id = 42
+        self.pk = 42
+        self.token = "payment-token-uuid"
+        self.status = PaymentStatus.WAITING
+        self.message = ""
+        self.currency = "USD"
+        self.total = Decimal("14.31")
+        self.captured_amount = Decimal("0")
+        self.transaction_id = ""
+        self.description = "Plan purchase"
+        self.extra_data = ""
+        self.renew_token_calls = []
+        self.renew_token = None
+        self.persisted = {}
+        self.saved = False
+
+    def save(self, update_fields=None):
+        self.saved = True
+        fields = update_fields if update_fields is not None else PERSISTED_FIELDS
+        for field in fields:
+            self.persisted[field] = getattr(self, field)
+
+    def change_status(self, status, message=""):
+        # Mirrors BasePayment.change_status: partial save on purpose.
+        self.status = status
+        self.message = message
+        self.save(update_fields=["status", "message"])
+
+    def get_process_url(self):
+        return f"/payments/process/{self.token}/"
+
+    def get_success_url(self):
+        return "/payment/success/"
+
+    def get_failure_url(self):
+        return "/payment/failure/"
+
+    def get_renew_token(self):
+        return self.renew_token
+
+    def set_renew_token(self, token, **kwargs):
+        self.renew_token_calls.append((token, kwargs))
+
+
+@override_settings(PAYMENT_HOST="example.com")
+class PaypalPPCPProviderTests(TestCase):
+    def setUp(self):
+        self.provider = PaypalPPCPProvider(
+            client_id="client-id",
+            secret="secret",
+            endpoint="https://api-m.sandbox.paypal.com",
+        )
+        self.vault_provider = PaypalPPCPProvider(
+            client_id="client-id",
+            secret="secret",
+            endpoint="https://api-m.sandbox.paypal.com",
+            vault=True,
+        )
+        self.payment = PaymentStub()
+        self.factory = RequestFactory()
+
+    def _mock_api(self, provider, responses):
+        """Patch OAuth + api_post; api_post returns responses in order."""
+        provider.get_access_token = MagicMock(return_value="Bearer A21AAFs")
+        mock = MagicMock(side_effect=responses)
+        provider.api_post = mock
+        return mock
+
+    def test_get_form_creates_order_and_redirects(self):
+        api = self._mock_api(self.provider, [CREATE_ORDER_RESPONSE])
+        with pytest.raises(RedirectNeeded) as cm:
+            self.provider.get_form(self.payment)
+        assert (
+            str(cm.value)
+            == "https://www.sandbox.paypal.com/checkoutnow?token=" + ORDER_ID
+        )
+        assert self.payment.status == PaymentStatus.WAITING
+        assert json.loads(self.payment.extra_data)["ppcp_order"]["id"] == ORDER_ID
+        body = api.call_args_list[0].args[1]
+        assert body["intent"] == "CAPTURE"
+        assert body["purchase_units"][0]["amount"] == {
+            "currency_code": "USD",
+            "value": "14.31",
+        }
+        assert "attributes" not in body["payment_source"]["paypal"]
+
+    def test_get_form_vault_variant_requests_vaulting(self):
+        api = self._mock_api(self.vault_provider, [CREATE_ORDER_RESPONSE])
+        with pytest.raises(RedirectNeeded):
+            self.vault_provider.get_form(self.payment)
+        body = api.call_args_list[0].args[1]
+        assert (
+            body["payment_source"]["paypal"]["attributes"]["vault"]["store_in_vault"]
+            == "ON_SUCCESS"
+        )
+
+    def test_get_form_reuses_existing_order(self):
+        self.payment.extra_data = json.dumps({"ppcp_order": CREATE_ORDER_RESPONSE})
+        api = self._mock_api(self.provider, [])
+        with pytest.raises(RedirectNeeded):
+            self.provider.get_form(self.payment)
+        api.assert_not_called()
+
+    def test_process_data_captures_and_confirms(self):
+        self.payment.extra_data = json.dumps({"ppcp_order": CREATE_ORDER_RESPONSE})
+        self._mock_api(self.provider, [capture_response()])
+        request = self.factory.get(
+            self.payment.get_process_url(),
+            {"token": ORDER_ID, "PayerID": "PAYER123"},
+        )
+        response = self.provider.process_data(self.payment, request)
+        assert self.payment.status == PaymentStatus.CONFIRMED
+        assert response.url == self.payment.get_success_url()
+        # Assert on PERSISTED state: change_status saves only status+message,
+        # so the provider must have explicitly saved the capture bookkeeping.
+        assert self.payment.persisted["transaction_id"] == CAPTURE_ID
+        assert self.payment.persisted["captured_amount"] == self.payment.total
+        assert "ppcp_capture" in json.loads(self.payment.persisted["extra_data"])
+
+    def test_process_data_stores_vault_token(self):
+        self.payment.extra_data = json.dumps({"ppcp_order": CREATE_ORDER_RESPONSE})
+        self._mock_api(self.vault_provider, [capture_response(vault=VAULT_ID)])
+        request = self.factory.get(
+            self.payment.get_process_url(),
+            {"token": ORDER_ID, "PayerID": "PAYER123"},
+        )
+        self.vault_provider.process_data(self.payment, request)
+        assert self.payment.status == PaymentStatus.CONFIRMED
+        token, kwargs = self.payment.renew_token_calls[0]
+        assert token == VAULT_ID
+        assert kwargs == {}
+
+    def test_process_data_without_approval_rejects(self):
+        self.payment.extra_data = json.dumps({"ppcp_order": CREATE_ORDER_RESPONSE})
+        api = self._mock_api(self.provider, [])
+        request = self.factory.get(self.payment.get_process_url(), {"token": ORDER_ID})
+        response = self.provider.process_data(self.payment, request)
+        assert self.payment.status == PaymentStatus.REJECTED
+        assert response.url == self.payment.get_failure_url()
+        api.assert_not_called()
+
+    def test_process_data_order_mismatch_fails(self):
+        self.payment.extra_data = json.dumps({"ppcp_order": CREATE_ORDER_RESPONSE})
+        self._mock_api(self.provider, [])
+        request = self.factory.get(
+            self.payment.get_process_url(),
+            {"token": "OTHER-ORDER", "PayerID": "PAYER123"},
+        )
+        with pytest.raises(PaymentError):
+            self.provider.process_data(self.payment, request)
+
+    def test_process_data_already_confirmed_is_idempotent(self):
+        self.payment.status = PaymentStatus.CONFIRMED
+        api = self._mock_api(self.provider, [])
+        request = self.factory.get(
+            self.payment.get_process_url(),
+            {"token": ORDER_ID, "PayerID": "PAYER123"},
+        )
+        response = self.provider.process_data(self.payment, request)
+        assert response.url == self.payment.get_success_url()
+        api.assert_not_called()
+
+    def test_autocomplete_with_wallet_charges_vault_token(self):
+        self.payment.renew_token = VAULT_ID
+        api = self._mock_api(self.vault_provider, [capture_response()])
+        self.vault_provider.autocomplete_with_wallet(self.payment)
+        assert self.payment.status == PaymentStatus.CONFIRMED
+        assert self.payment.persisted["transaction_id"] == CAPTURE_ID
+        assert "ppcp_capture" in json.loads(self.payment.persisted["extra_data"])
+        body = api.call_args_list[0].args[1]
+        assert body["payment_source"]["token"] == {
+            "id": VAULT_ID,
+            "type": "PAYMENT_METHOD_TOKEN",
+        }
+
+    def test_autocomplete_with_wallet_captures_created_order(self):
+        self.payment.renew_token = VAULT_ID
+        created = {"id": ORDER_ID, "status": "CREATED"}
+        self._mock_api(self.vault_provider, [created, capture_response()])
+        self.vault_provider.autocomplete_with_wallet(self.payment)
+        assert self.payment.status == PaymentStatus.CONFIRMED
+
+    def test_autocomplete_with_wallet_without_token_fails(self):
+        with pytest.raises(PaymentError):
+            self.provider.autocomplete_with_wallet(self.payment)
+
+    def test_refund(self):
+        self.payment.transaction_id = CAPTURE_ID
+        self.payment.captured_amount = self.payment.total
+        api = self._mock_api(self.provider, [{"status": "COMPLETED"}])
+        refunded = self.provider.refund(self.payment, Decimal("5.00"))
+        assert refunded == Decimal("5.00")
+        url = api.call_args_list[0].args[0]
+        assert CAPTURE_ID in url
+
+    def test_refund_without_capture_fails(self):
+        with pytest.raises(PaymentError):
+            self.provider.refund(self.payment)
+
+    def test_get_access_token_caches(self):
+        with patch("payments.paypal.ppcp.requests.post") as mock_post:
+            mock_post.return_value.ok = True
+            mock_post.return_value.json.return_value = OAUTH_RESPONSE
+            token1 = self.provider.get_access_token()
+            token2 = self.provider.get_access_token()
+        assert token1 == "Bearer A21AAFs"
+        assert token1 == token2
+        assert mock_post.call_count == 1
+
+    def test_init_rejects_unknown_kwargs(self):
+        with pytest.raises(TypeError):
+            PaypalPPCPProvider(
+                client_id="client-id",
+                secret="secret",
+                unexpected_option=True,
+            )
+
+    def test_init_rejects_preauthorization(self):
+        """capture=False (pre-authorization) is not implemented yet.
+
+        The legacy PaypalProvider authorizes in this mode; failing at
+        configuration time prevents a migrating integrator from silently
+        capturing payments they meant to only authorize.
+        """
+        with pytest.raises(NotImplementedError):
+            PaypalPPCPProvider(
+                client_id="client-id",
+                secret="secret",
+                capture=False,
+            )
+
+    def test_api_post_sends_idempotency_header(self):
+        self.provider.get_access_token = MagicMock(return_value="Bearer A21AAFs")
+        with patch("payments.paypal.ppcp.requests.post") as mock_post:
+            mock_post.return_value.ok = True
+            mock_post.return_value.json.return_value = {"id": ORDER_ID}
+            result = self.provider.api_post(
+                self.provider.orders_url, {"intent": "CAPTURE"}, request_id="create-x"
+            )
+        assert result == {"id": ORDER_ID}
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["PayPal-Request-Id"] == "create-x"
+        assert headers["Authorization"] == "Bearer A21AAFs"
+
+    def test_api_post_logs_and_raises_on_error(self):
+        self.provider.get_access_token = MagicMock(return_value="Bearer A21AAFs")
+        with patch("payments.paypal.ppcp.requests.post") as mock_post:
+            mock_post.return_value.ok = False
+            mock_post.return_value.status_code = 422
+            mock_post.return_value.text = '{"name": "UNPROCESSABLE_ENTITY"}'
+            mock_post.return_value.raise_for_status.side_effect = requests.HTTPError(
+                "422"
+            )
+            with (
+                self.assertLogs("payments.paypal.ppcp", level="WARNING"),
+                pytest.raises(requests.HTTPError),
+            ):
+                self.provider.api_post(self.provider.orders_url)
+
+    def test_get_form_saves_unsaved_payment(self):
+        self.payment.id = None
+        self._mock_api(self.provider, [CREATE_ORDER_RESPONSE])
+        with pytest.raises(RedirectNeeded):
+            self.provider.get_form(self.payment)
+        assert self.payment.saved
+
+    def test_get_form_without_approval_link_fails(self):
+        no_link_order = {"id": ORDER_ID, "status": "CREATED", "links": []}
+        self._mock_api(self.provider, [no_link_order])
+        with pytest.raises(PaymentError):
+            self.provider.get_form(self.payment)
+
+    def test_process_data_incomplete_capture_rejects(self):
+        self.payment.extra_data = json.dumps({"ppcp_order": CREATE_ORDER_RESPONSE})
+        self._mock_api(self.provider, [{"id": ORDER_ID, "status": "PENDING"}])
+        request = self.factory.get(
+            self.payment.get_process_url(),
+            {"token": ORDER_ID, "PayerID": "PAYER123"},
+        )
+        response = self.provider.process_data(self.payment, request)
+        assert self.payment.status == PaymentStatus.REJECTED
+        assert response.url == self.payment.get_failure_url()
+
+    def test_process_data_capture_without_capture_object_fails(self):
+        self.payment.extra_data = json.dumps({"ppcp_order": CREATE_ORDER_RESPONSE})
+        self._mock_api(
+            self.provider,
+            [{"id": ORDER_ID, "status": "COMPLETED", "purchase_units": []}],
+        )
+        request = self.factory.get(
+            self.payment.get_process_url(),
+            {"token": ORDER_ID, "PayerID": "PAYER123"},
+        )
+        with pytest.raises(PaymentError):
+            self.provider.process_data(self.payment, request)
+
+    def test_extract_capture_empty_captures_list_fails(self):
+        with pytest.raises(PaymentError):
+            PaypalPPCPProvider._extract_capture(
+                {"id": ORDER_ID, "purchase_units": [{"payments": {"captures": []}}]}
+            )
+
+    def test_process_data_capture_without_fee_breakdown_confirms(self):
+        response_without_fee = capture_response()
+        del response_without_fee["purchase_units"][0]["payments"]["captures"][0][
+            "seller_receivable_breakdown"
+        ]
+        self.payment.extra_data = json.dumps({"ppcp_order": CREATE_ORDER_RESPONSE})
+        self._mock_api(self.provider, [response_without_fee])
+        request = self.factory.get(
+            self.payment.get_process_url(),
+            {"token": ORDER_ID, "PayerID": "PAYER123"},
+        )
+        self.provider.process_data(self.payment, request)
+        assert self.payment.status == PaymentStatus.CONFIRMED
+
+    def test_autocomplete_with_wallet_api_error_sets_error_status(self):
+        self.payment.renew_token = VAULT_ID
+        self._mock_api(self.vault_provider, requests.HTTPError("boom"))
+        self.vault_provider.autocomplete_with_wallet(self.payment)
+        assert self.payment.status == PaymentStatus.ERROR
+
+    def test_autocomplete_with_wallet_incomplete_capture_rejects(self):
+        self.payment.renew_token = VAULT_ID
+        created = {"id": ORDER_ID, "status": "CREATED"}
+        still_pending = {"id": ORDER_ID, "status": "PENDING"}
+        self._mock_api(self.vault_provider, [created, still_pending])
+        self.vault_provider.autocomplete_with_wallet(self.payment)
+        assert self.payment.status == PaymentStatus.REJECTED
+
+    def test_autocomplete_with_wallet_without_fee_breakdown_confirms(self):
+        response_without_fee = capture_response()
+        del response_without_fee["purchase_units"][0]["payments"]["captures"][0][
+            "seller_receivable_breakdown"
+        ]
+        self.payment.renew_token = VAULT_ID
+        self._mock_api(self.vault_provider, [response_without_fee])
+        self.vault_provider.autocomplete_with_wallet(self.payment)
+        assert self.payment.status == PaymentStatus.CONFIRMED
+
+    def test_refund_full_amount_without_argument(self):
+        self.payment.transaction_id = CAPTURE_ID
+        self.payment.captured_amount = self.payment.total
+        api = self._mock_api(self.provider, [{"status": "COMPLETED"}])
+        refunded = self.provider.refund(self.payment)
+        assert refunded == self.payment.total
+        body = api.call_args_list[0].args[1]
+        assert body == {}
+
+    def test_refund_failed_status_raises(self):
+        self.payment.transaction_id = CAPTURE_ID
+        self._mock_api(self.provider, [{"status": "FAILED"}])
+        with pytest.raises(PaymentError):
+            self.provider.refund(self.payment, Decimal("5.00"))
+
+    def _mock_delete(self, status_code):
+        self.provider.get_access_token = MagicMock(return_value="Bearer A21AAFs")
+        patcher = patch("payments.paypal.ppcp.requests.delete")
+        mock_delete = patcher.start()
+        self.addCleanup(patcher.stop)
+        mock_delete.return_value.status_code = status_code
+        mock_delete.return_value.ok = status_code < 400
+        if status_code >= 400:
+            mock_delete.return_value.raise_for_status.side_effect = requests.HTTPError(
+                str(status_code)
+            )
+        return mock_delete
+
+    def test_erase_wallet(self):
+        mock_delete = self._mock_delete(204)
+        self.provider.erase_wallet(VAULT_ID)
+        url = mock_delete.call_args.args[0]
+        assert (
+            url
+            == "https://api-m.sandbox.paypal.com/v3/vault/payment-tokens/" + VAULT_ID
+        )
+
+    def test_erase_wallet_already_gone_is_ok(self):
+        self._mock_delete(404)
+        self.provider.erase_wallet(VAULT_ID)
+
+    def test_erase_wallet_error_raises(self):
+        self._mock_delete(500)
+        with pytest.raises(requests.HTTPError):
+            self.provider.erase_wallet(VAULT_ID)

--- a/payments/test_wallet.py
+++ b/payments/test_wallet.py
@@ -58,6 +58,20 @@ def test_base_wallet_default_status():
     assert wallet.status == WalletStatus.PENDING
 
 
+class MinimalPayment(BasePayment):
+    """Payment without wallet overrides - exercises the BasePayment defaults."""
+
+    class Meta:
+        app_label = "test_wallet"
+
+
+def test_payment_base_defaults_return_none():
+    """BasePayment hook defaults return None when not overridden."""
+    payment = MinimalPayment()
+    assert payment.get_renew_token() is None
+    assert payment.get_renew_data() is None
+
+
 def test_payment_get_renew_token_default():
     """get_renew_token() returns None by default."""
     payment = Payment()

--- a/payments/test_wallet.py
+++ b/payments/test_wallet.py
@@ -1,0 +1,234 @@
+"""
+Mock-based unit tests for wallet interface logic.
+
+These tests verify the wallet interface using mocks, following the established
+pattern from test_core.py. They test interface contracts and simple logic without
+needing a database.
+
+For integration tests that verify model lifecycle and provider workflows with
+a real database, see testapp/testapp/testmain/test_wallet.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from payments import PaymentStatus
+from payments import WalletStatus
+from payments.core import provider_factory
+from payments.models import BasePayment
+from payments.models import BaseWallet
+
+
+class Wallet(BaseWallet):
+    """Test wallet model (not persisted to database)."""
+
+    class Meta:
+        app_label = "test_wallet"
+
+
+class Payment(BasePayment):
+    """Test payment model (not persisted to database)."""
+
+    def get_renew_token(self):
+        """Override to support wallet token retrieval for testing."""
+        if (
+            hasattr(self, "wallet")
+            and self.wallet
+            and self.wallet.status == WalletStatus.ACTIVE
+        ):
+            return self.wallet.token
+        return None
+
+    class Meta:
+        app_label = "test_wallet"
+
+
+def test_wallet_status_choices():
+    """Verify WalletStatus constants are defined."""
+    assert WalletStatus.PENDING == "pending"
+    assert WalletStatus.ACTIVE == "active"
+    assert WalletStatus.ERASED == "erased"
+
+
+def test_base_wallet_default_status():
+    """New wallets start in PENDING status."""
+    wallet = Wallet()
+    assert wallet.status == WalletStatus.PENDING
+
+
+def test_payment_get_renew_token_default():
+    """get_renew_token() returns None by default."""
+    payment = Payment()
+    assert payment.get_renew_token() is None
+
+
+def test_payment_get_renew_data_default():
+    """get_renew_data() returns token dict by default."""
+    payment = Payment()
+    assert payment.get_renew_data() is None
+
+
+def test_payment_get_renew_data_returns_token_dict():
+    """get_renew_data() wraps token in dict."""
+    payment = Payment()
+    with patch.object(payment, "get_renew_token", return_value="test_token"):
+        data = payment.get_renew_data()
+        assert data == {"token": "test_token"}
+
+
+def test_payment_set_renew_token_default():
+    """set_renew_token() is a no-op by default (subclasses override)."""
+    payment = Payment()
+    # Should not raise
+    payment.set_renew_token("test_token")
+
+
+def test_provider_finalize_wallet_payment_without_wallet():
+    """_finalize_wallet_payment handles missing wallet gracefully."""
+    provider = provider_factory("default")
+    payment = Payment(status=PaymentStatus.CONFIRMED)
+    payment.wallet = None
+
+    # Should not raise
+    provider._finalize_wallet_payment(payment)
+
+
+def test_wallet_extra_data_stores_metadata():
+    """Wallet extra_data can store provider-specific metadata."""
+    wallet = Wallet(token="pm_test")
+    wallet.extra_data = {
+        "card_masked_number": "4242",
+        "card_expire_year": "2025",
+        "stripe_customer_id": "cus_test",
+    }
+
+    assert wallet.extra_data["card_masked_number"] == "4242"
+    assert wallet.extra_data["stripe_customer_id"] == "cus_test"
+
+
+def test_get_renew_token_with_inactive_wallet():
+    """get_renew_token returns None for non-ACTIVE wallets."""
+    # Test with PENDING wallet
+    wallet_pending = Mock(status=WalletStatus.PENDING, token="token1")
+    payment_pending = Payment()
+    payment_pending.wallet = wallet_pending
+
+    assert payment_pending.get_renew_token() is None
+
+    # Test with ERASED wallet
+    wallet_erased = Mock(status=WalletStatus.ERASED, token="token2")
+    payment_erased = Payment()
+    payment_erased.wallet = wallet_erased
+
+    assert payment_erased.get_renew_token() is None
+
+
+def test_get_renew_token_with_active_wallet():
+    """get_renew_token returns token for ACTIVE wallet."""
+    # Mock wallet with ACTIVE status
+    wallet = Mock()
+    wallet.status = WalletStatus.ACTIVE
+    wallet.token = "pm_active_token"
+    wallet.__bool__ = lambda self: True  # Make wallet truthy
+
+    payment = Payment()
+    payment.wallet = wallet
+
+    assert payment.get_renew_token() == "pm_active_token"
+
+
+def test_autocomplete_with_wallet_calls_provider():
+    """Payment.autocomplete_with_wallet calls provider implementation."""
+    payment = Payment(variant="default")
+
+    with patch("payments.models.provider_factory") as mock_factory:
+        mock_provider = Mock()
+        mock_factory.return_value = mock_provider
+
+        payment.autocomplete_with_wallet()
+
+        mock_provider.autocomplete_with_wallet.assert_called_once_with(payment)
+
+
+def test_provider_erase_wallet_default_is_noop():
+    """BasicProvider.erase_wallet accepts a token and does nothing by default.
+
+    Providers override this to revoke the stored payment method at their
+    gateway; the wallet bookkeeping (marking ERASED) is the integrator's
+    follow-up via wallet.erase().
+    """
+    provider = provider_factory("default")
+
+    provider.erase_wallet("token-to-revoke")  # must not raise
+
+
+def test_erased_wallet_token_preserved():
+    """Erased wallet keeps token for audit purposes."""
+    wallet = Wallet(
+        status=WalletStatus.ACTIVE,
+        token="pm_historical",
+        extra_data={"card_masked_number": "1234"},
+    )
+
+    with patch.object(BaseWallet, "save"):
+        wallet.erase()
+
+    assert wallet.status == WalletStatus.ERASED
+    assert wallet.token == "pm_historical"  # Preserved
+    assert wallet.extra_data["card_masked_number"] == "1234"  # Preserved
+
+
+def test_set_renew_token_with_card_details():
+    """set_renew_token can store card details in extra_data."""
+    payment = Payment(variant="test")
+
+    # Subclass would implement this, but we can test the interface
+    with patch.object(payment, "set_renew_token"):
+        payment.set_renew_token(
+            token="pm_new",
+            card_expire_year="2025",
+            card_expire_month="12",
+            card_masked_number="4242",
+        )
+
+
+def test_documentation_pattern_wallet_fk():
+    """Document the simple wallet FK pattern."""
+    # Pattern shown in testapp/testmain/models.py
+    # This test documents the interface, actual DB behavior tested in integration tests
+    wallet = Mock()
+    wallet.status = WalletStatus.ACTIVE
+    wallet.token = "pm_test"
+    wallet.__bool__ = lambda self: True
+
+    payment = Payment(variant="test")
+    payment.wallet = wallet
+
+    # get_renew_token checks wallet status and returns token
+    token = payment.get_renew_token()
+    assert token == "pm_test"
+
+
+def test_documentation_pattern_custom_storage():
+    """Document custom storage pattern without FK."""
+    # Some apps might store token differently (e.g., on RecurringUserPlan)
+    payment = Payment(variant="test")
+
+    # Override get_renew_token to return from custom storage
+    with patch.object(payment, "get_renew_token", return_value="custom_token"):
+        token = payment.get_renew_token()
+        assert token == "custom_token"
+
+
+def test_get_renew_data_for_multi_value_providers():
+    """get_renew_data supports providers needing multiple values (Stripe)."""
+    payment = Payment(variant="stripe")
+
+    # Subclass returns both token and customer_id for Stripe
+    mock_data = {"token": "pm_test", "customer_id": "cus_test"}
+    with patch.object(payment, "get_renew_data", return_value=mock_data):
+        data = payment.get_renew_data()
+        assert data["token"] == "pm_test"
+        assert data["customer_id"] == "cus_test"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,10 +77,11 @@ addopts = [
   "--cov-report=term-missing:skip-covered",
   "--no-cov-on-fail",
   "--color=yes",
+  "--ignore=testapp/payments",  # Ignore symlink to avoid duplicate test discovery
 ]
-testpaths = "payments"
+testpaths = ["payments", "testapp/testapp"]
 DJANGO_SETTINGS_MODULE = "test_settings"
-pythonpath = "."
+pythonpath = [".", "testapp/testapp"]  # Root first to avoid symlink issues
 
 [tool.ruff.lint]
 extend-select = [

--- a/test_settings.py
+++ b/test_settings.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import os
 import sys
 
+from django.urls import include
+from django.urls import path
+
 # Add testapp/testapp to Python path so testmain can be imported
 TESTAPP_ROOT = os.path.join(os.path.dirname(__file__), "testapp", "testapp")
 if TESTAPP_ROOT not in sys.path:
     sys.path.insert(0, TESTAPP_ROOT)
-
-from django.urls import include
-from django.urls import path
 
 PROJECT_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "payments"))
 TEMPLATES = [

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 import os
+import sys
+
+# Add testapp/testapp to Python path so testmain can be imported
+TESTAPP_ROOT = os.path.join(os.path.dirname(__file__), "testapp", "testapp")
+if TESTAPP_ROOT not in sys.path:
+    sys.path.insert(0, TESTAPP_ROOT)
 
 from django.urls import include
 from django.urls import path
@@ -16,7 +22,13 @@ TEMPLATES = [
 SECRET_KEY = "NOTREALLY"
 PAYMENT_HOST = "example.com"
 
-INSTALLED_APPS = ["payments", "django.contrib.sites"]
+INSTALLED_APPS = [
+    "payments",
+    "django.contrib.sites",
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+    "testmain",
+]
 
 ROOT_URLCONF = "test_settings"
 
@@ -24,6 +36,8 @@ urlpatterns = [
     path("payments/", include("payments.urls")),
 ]
 
+# Database configuration for tests that use ORM operations
+# (e.g., wallet tests that verify model lifecycle and relationships)
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",

--- a/testapp/testapp/testmain/migrations/0004_wallet_payment_wallet.py
+++ b/testapp/testapp/testmain/migrations/0004_wallet_payment_wallet.py
@@ -1,0 +1,90 @@
+# Generated migration for wallet support
+from __future__ import annotations
+
+import django.db.models.deletion
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("testmain", "0003_alter_payment_status"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Wallet",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "token",
+                    models.CharField(
+                        blank=True,
+                        default="",
+                        help_text=(
+                            "Payment method token/ID from provider "
+                            "(e.g., PaymentMethod ID for Stripe, card token for PayU)"
+                        ),
+                        max_length=255,
+                        verbose_name="wallet token/id",
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("active", "Active"),
+                            ("erased", "Erased"),
+                        ],
+                        default="pending",
+                        max_length=10,
+                    ),
+                ),
+                (
+                    "extra_data",
+                    models.JSONField(
+                        default=dict,
+                        help_text=(
+                            "Provider-specific data "
+                            "(e.g., card details, expiry dates, customer IDs)"
+                        ),
+                        verbose_name="extra data",
+                    ),
+                ),
+                (
+                    "payment_provider",
+                    models.CharField(
+                        help_text=(
+                            "Payment variant name "
+                            "(e.g., 'stripe-recurring', 'payu-recurring')"
+                        ),
+                        max_length=50,
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+        migrations.AddField(
+            model_name="payment",
+            name="wallet",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Wallet used for recurring payments",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="payments",
+                to="testmain.wallet",
+            ),
+        ),
+    ]

--- a/testapp/testapp/testmain/models.py
+++ b/testapp/testapp/testmain/models.py
@@ -2,14 +2,60 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from django.db import models
+
 from payments import PurchasedItem
+from payments import WalletStatus
 from payments.models import BasePayment
+from payments.models import BaseWallet
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
+class Wallet(BaseWallet):
+    """
+    Example wallet implementation for recurring payments.
+
+    This demonstrates how to extend BaseWallet for your application.
+    In a real application, you would add a ForeignKey to your User model.
+    """
+
+    payment_provider = models.CharField(
+        max_length=50,
+        help_text="Payment variant name (e.g., 'stripe-recurring', 'payu-recurring')",
+    )
+    # In real app: user = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    class Meta:
+        app_label = "testmain"
+
+    def payment_completed(self, payment):
+        """Custom logic after successful payment."""
+        super().payment_completed(payment)
+        # Add your custom logic here (notifications, logging, etc.)
+
+
 class Payment(BasePayment):
+    """Example payment implementation with wallet support.
+
+    Demonstrates wallet-based recurring payments: the wallet stores the
+    provider's stored-payment-method token, and later payments are charged
+    server-side without user interaction.
+    """
+
+    wallet = models.ForeignKey(
+        Wallet,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="payments",
+        help_text="Wallet used for recurring payments",
+    )
+
+    class Meta:
+        app_label = "testmain"
+
     def get_failure_url(self) -> str:
         return "http://localhost:8000/test/payment-failure"
 
@@ -24,3 +70,62 @@ class Payment(BasePayment):
             price=self.total,
             currency=self.currency,
         )
+
+    def get_renew_token(self):
+        """
+        Get payment method token for recurring payments.
+
+        This implementation uses the wallet FK. For projects with different
+        architecture (e.g., token stored elsewhere), override this method.
+        """
+        if self.wallet and self.wallet.status == WalletStatus.ACTIVE:
+            return self.wallet.token
+        return None
+
+    def get_renew_data(self):
+        """
+        Get payment method data (token and customer_id) for recurring payments.
+
+        Returns dict with 'token' and 'customer_id' needed for server-initiated
+        recurring charges. For Stripe, both are required for off_session payments.
+        """
+        if self.wallet and self.wallet.status == WalletStatus.ACTIVE:
+            return {
+                "token": self.wallet.token,
+                "customer_id": self.wallet.extra_data.get("customer_id"),
+            }
+        return None
+
+    def set_renew_token(
+        self,
+        token,
+        customer_id=None,
+        card_expire_year=None,
+        card_expire_month=None,
+        card_masked_number=None,
+        automatic_renewal=True,
+    ):
+        """
+        Store payment method token and customer_id after successful payment.
+
+        This implementation stores in the wallet. For projects with different
+        architecture, override this method.
+        """
+        if not self.wallet:
+            # Create wallet if it doesn't exist (first payment)
+            self.wallet = Wallet.objects.create(payment_provider=self.variant)
+            self.save(update_fields=["wallet"])
+
+        # Store token and card details
+        self.wallet.token = token
+        self.wallet.extra_data.update(
+            {
+                "customer_id": customer_id,
+                "card_expire_year": card_expire_year,
+                "card_expire_month": card_expire_month,
+                "card_masked_number": card_masked_number,
+                "automatic_renewal": automatic_renewal,
+            }
+        )
+        self.wallet.save(update_fields=["token", "extra_data"])
+        self.wallet.activate()  # Mark as active and ready for use

--- a/testapp/testapp/testmain/test_wallet.py
+++ b/testapp/testapp/testmain/test_wallet.py
@@ -1,0 +1,276 @@
+"""
+Integration tests for wallet-based recurring payments.
+
+These tests verify the wallet interface with real database operations and
+model lifecycle. They complement the mock-based unit tests in
+payments/test_wallet.py by testing:
+- Real model state transitions with database saves
+- Full provider workflows with real Payment/Wallet instances
+- End-to-end payment scenarios with DB verification
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.test import TestCase
+from testmain.models import Payment
+from testmain.models import Wallet
+
+from payments import PaymentError
+from payments import PaymentStatus
+from payments import WalletStatus
+from payments.core import provider_factory
+
+
+class WalletStateTransitionTests(TestCase):
+    """Test wallet state transitions with real database operations."""
+
+    def test_base_wallet_payment_completed_activates(self):
+        """payment_completed() activates pending wallet on confirmed payment."""
+        wallet = Wallet.objects.create(payment_provider="test")
+        payment = Payment.objects.create(
+            variant="default",
+            status=PaymentStatus.CONFIRMED,
+            total=Decimal("20.00"),
+            currency="USD",
+        )
+
+        wallet.payment_completed(payment)
+
+        # Verify DB state
+        wallet.refresh_from_db()
+        assert wallet.status == WalletStatus.ACTIVE
+
+    def test_base_wallet_payment_completed_ignores_non_confirmed(self):
+        """payment_completed() doesn't activate on non-confirmed payments."""
+        wallet = Wallet.objects.create(payment_provider="test")
+        payment = Payment.objects.create(
+            variant="default",
+            status=PaymentStatus.WAITING,
+            total=Decimal("20.00"),
+            currency="USD",
+        )
+
+        wallet.payment_completed(payment)
+
+        # Verify DB state unchanged
+        wallet.refresh_from_db()
+        assert wallet.status == WalletStatus.PENDING
+
+    def test_base_wallet_activate(self):
+        """activate() marks wallet as ACTIVE."""
+        wallet = Wallet.objects.create(payment_provider="test")
+
+        wallet.activate()
+
+        # Verify DB state
+        wallet.refresh_from_db()
+        assert wallet.status == WalletStatus.ACTIVE
+
+    def test_base_wallet_erase(self):
+        """erase() marks wallet as ERASED."""
+        wallet = Wallet.objects.create(
+            payment_provider="test",
+            token="test_token",
+            status=WalletStatus.ACTIVE,
+        )
+
+        wallet.erase()
+
+        # Verify DB state
+        wallet.refresh_from_db()
+        assert wallet.status == WalletStatus.ERASED
+        assert wallet.token == "test_token"  # Token preserved for audit
+
+    def test_base_wallet_payment_completed_already_active(self):
+        """payment_completed() doesn't change status if already active."""
+        wallet = Wallet.objects.create(
+            payment_provider="test", status=WalletStatus.ACTIVE
+        )
+        payment = Payment.objects.create(
+            variant="default",
+            status=PaymentStatus.CONFIRMED,
+            total=Decimal("20.00"),
+            currency="USD",
+        )
+
+        wallet.payment_completed(payment)
+
+        # Verify status unchanged
+        wallet.refresh_from_db()
+        assert wallet.status == WalletStatus.ACTIVE
+
+
+class DummyProviderWorkflowTests(TestCase):
+    """Test DummyProvider wallet workflows with real models."""
+
+    def test_dummy_provider_autocomplete_with_wallet(self):
+        """DummyProvider implements autocomplete_with_wallet."""
+        provider = provider_factory("default")
+        wallet = Wallet.objects.create(
+            payment_provider="default",
+            token="test_token",
+            status=WalletStatus.ACTIVE,
+        )
+        payment = Payment.objects.create(
+            variant="default",
+            status=PaymentStatus.WAITING,
+            total=Decimal("20.00"),
+            currency="USD",
+            wallet=wallet,
+        )
+
+        provider.autocomplete_with_wallet(payment)
+
+        # Verify DB state
+        payment.refresh_from_db()
+        assert payment.status == PaymentStatus.CONFIRMED
+        assert payment.captured_amount == Decimal("20.00")
+        assert payment.transaction_id.startswith("dummy-wallet-charge-")
+
+    def test_autocomplete_with_wallet_without_token_fails(self):
+        """autocomplete_with_wallet raises error without token."""
+        provider = provider_factory("default")
+        wallet = Wallet.objects.create(
+            payment_provider="default",
+            status=WalletStatus.ACTIVE,  # Active wallet but no token
+            token="",  # Empty token
+        )
+        payment = Payment.objects.create(
+            variant="default",
+            status=PaymentStatus.WAITING,
+            total=Decimal("20.00"),
+            currency="USD",
+            wallet=wallet,
+        )
+
+        with pytest.raises(PaymentError, match="No payment method token"):
+            provider.autocomplete_with_wallet(payment)
+
+    def test_dummy_provider_inactive_wallet_no_token(self):
+        """Payment.get_renew_token() returns None for inactive wallets."""
+        provider = provider_factory("default")
+        wallet = Wallet.objects.create(
+            payment_provider="default",
+            token="test_token",
+            status=WalletStatus.PENDING,  # Not active
+        )
+        payment = Payment.objects.create(
+            variant="default",
+            status=PaymentStatus.WAITING,
+            total=Decimal("20.00"),
+            currency="USD",
+            wallet=wallet,
+        )
+
+        # get_renew_token() returns None for PENDING wallets (security feature)
+        # So DummyProvider raises error about missing token
+        with pytest.raises(PaymentError, match="No payment method token"):
+            provider.autocomplete_with_wallet(payment)
+
+    def test_provider_finalize_wallet_payment(self):
+        """_finalize_wallet_payment triggers wallet.payment_completed."""
+        provider = provider_factory("default")
+        wallet = Wallet.objects.create(payment_provider="default")
+        payment = Payment.objects.create(
+            variant="default",
+            status=PaymentStatus.CONFIRMED,
+            total=Decimal("20.00"),
+            currency="USD",
+            wallet=wallet,
+        )
+
+        provider._finalize_wallet_payment(payment)
+
+        # Verify wallet was activated
+        wallet.refresh_from_db()
+        assert wallet.status == WalletStatus.ACTIVE
+
+
+class EndToEndWorkflowTests(TestCase):
+    """Test complete payment workflows with real database state."""
+
+    def test_first_payment_workflow(self):
+        """Test complete first payment workflow."""
+        provider = provider_factory("default")
+        wallet = Wallet.objects.create(
+            payment_provider="default", status=WalletStatus.PENDING
+        )
+        payment = Payment.objects.create(
+            variant="default",
+            status=PaymentStatus.WAITING,
+            total=Decimal("29.99"),
+            currency="USD",
+            wallet=wallet,
+        )
+
+        # Simulate payment completion
+        payment.status = PaymentStatus.CONFIRMED
+        payment.save()
+
+        # Provider should finalize (trigger wallet activation)
+        provider._finalize_wallet_payment(payment)
+
+        # Verify DB state
+        wallet.refresh_from_db()
+        assert wallet.status == WalletStatus.ACTIVE
+
+    def test_recurring_payment_workflow(self):
+        """Test recurring payment with stored token."""
+        provider = provider_factory("default")
+        wallet = Wallet.objects.create(
+            payment_provider="default",
+            token="stored_pm_token",
+            status=WalletStatus.ACTIVE,
+        )
+        payment = Payment.objects.create(
+            variant="default",
+            status=PaymentStatus.WAITING,
+            total=Decimal("35.00"),  # Different amount than first payment
+            currency="USD",
+            wallet=wallet,
+        )
+
+        provider.autocomplete_with_wallet(payment)
+
+        # Verify DB state
+        payment.refresh_from_db()
+        assert payment.status == PaymentStatus.CONFIRMED
+        assert payment.captured_amount == Decimal("35.00")
+
+    def test_variable_amount_charges(self):
+        """Wallet supports charging different amounts."""
+        provider = provider_factory("default")
+        wallet = Wallet.objects.create(
+            payment_provider="default",
+            token="pm_token",
+            status=WalletStatus.ACTIVE,
+        )
+
+        # First charge: $20
+        payment1 = Payment.objects.create(
+            variant="default",
+            total=Decimal("20.00"),
+            currency="USD",
+            wallet=wallet,
+        )
+        provider.autocomplete_with_wallet(payment1)
+
+        # Verify first charge
+        payment1.refresh_from_db()
+        assert payment1.captured_amount == Decimal("20.00")
+
+        # Second charge: $35 (different amount!)
+        payment2 = Payment.objects.create(
+            variant="default",
+            total=Decimal("35.00"),
+            currency="USD",
+            wallet=wallet,
+        )
+        provider.autocomplete_with_wallet(payment2)
+
+        # Verify second charge
+        payment2.refresh_from_db()
+        assert payment2.captured_amount == Decimal("35.00")

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ ignore_outcome =
     djmain: True
 ignore_errors =
     djmain: True
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}/testapp/testapp
 deps=
     dj52: Django>=5.2,<5.3
     dj60: Django>=6.0,<6.1


### PR DESCRIPTION
This PR adds a new PayPal provider based on the current PayPal Complete
Payments platform (Orders API v2 + Vault). PayPal has deprecated the v1
Payments API that the current `PaypalProvider` uses, so a new provider is
needed anyway - and this one also implements the wallet interface from
#217, so it supports server-initiated recurring payments.

**Depends on #217** - the branch is based on it and the recurring part
uses the wallet interface from there. When #217 gets merged, I will
rebase this to main. Until then the diff shows also the #217 commits.

What it does:

- Checkout with the standard redirect flow - create order, redirect the
  user to PayPal approval page, capture synchronously when they return.
  The raw API responses (including the fee breakdown in
  `seller_receivable_breakdown`) are kept in `payment.extra_data`.
- With `vault=True` the payment method is stored during checkout
  (`store_in_vault=ON_SUCCESS`) and the token is passed to
  `payment.set_renew_token()`. Later payments can then be charged by
  `autocomplete_with_wallet()` without any user interaction.
  `erase_wallet(token)` deletes the vaulted method (404 is treated as
  already deleted, so cancelling twice is idempotent).
- Refunds through the Payments v2 API.
- All mutating calls send the `PayPal-Request-Id` idempotency header, so
  retries (timeouts, double-clicked return URLs) replay the original
  result instead of double-charging.

The old `PaypalProvider`/`PaypalCardProvider` are not touched - they keep
working for existing integrations. I added a "Migrating from
PaypalProvider" section to the docs with the differences: mainly
`capture=False` (pre-authorization) is not implemented yet and raises
`NotImplementedError` at configuration time, `transaction_id` now
contains the capture id instead of the v1 payment id, and `extra_data`
has a different layout.

I am running this exact flow in production on our server - checkout,
vaulting, server-initiated renewals, refunds and cancellation are all
verified there. One lesson from that is directly in the code:
`change_status()` persists only status+message (`update_fields`), so the
provider explicitly saves the bookkeeping fields before calling it - we
silently lost `transaction_id` in production before finding this. The
test suite contains a payment stub that reproduces this partial-save
behaviour and asserts on what would actually reach the database.

Not implemented yet (possible follow-ups): webhooks (payment state is
driven by the synchronous capture on the return URL), pre-authorization
(`capture=False`), and Advanced Card Payments (the
`PaypalCardProvider` equivalent).