### PR TITLE
Serialize concurrent process_data callbacks with select_for_update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ releases, in reverse chronological order.
 v4.0.0
 ------
 
+- Fixed a race between concurrent callbacks for the same payment: the
+  ``process_data`` view now fetches the payment with ``select_for_update()``
+  inside its existing transaction, so e.g. a provider's asynchronous webhook
+  and the customer's browser POSTing to the same process URL are serialized
+  instead of interleaving on stale instances (which could overwrite a
+  captured, CONFIRMED payment's state with a stale failure). On databases
+  without ``SELECT ... FOR UPDATE`` support (such as SQLite) the behavior is
+  unchanged.
 - **Breaking**: Webhook error responses in ``static_callback`` endpoint now
   return JSON instead of raising ``Http404``. Error responses include
   ``variant`` and ``error_code`` fields for easier debugging. This helps

--- a/payments/test_urls.py
+++ b/payments/test_urls.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import uuid
+from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
+from django.db.models import QuerySet
+from django.http import HttpResponse
 from django.test import TestCase
 
 from payments import PaymentError
@@ -82,3 +86,42 @@ class StaticCallbackTestCase(TestCase):
         assert data["variant"] == "dummy"
         # Token should not be exposed in error response for security
         assert "token" not in data
+
+
+class ProcessDataLockingTestCase(TestCase):
+    """Concurrent callbacks for one payment must be serialized."""
+
+    @patch("payments.urls.provider_factory")
+    @patch("payments.urls.get_payment_model")
+    def test_process_data_locks_the_payment_row(self, mock_get_model, mock_factory):
+        """The payment must be fetched with select_for_update().
+
+        ``process_data`` already runs inside ``@atomic``, but it used to
+        fetch the payment without a row lock. Two concurrent callbacks for
+        the same payment - typically the provider's asynchronous webhook
+        and the customer's browser POSTing to the same process URL - then
+        interleave on instances loaded before each other's commit, and the
+        loser overwrites the winner's state (observed in production as a
+        captured, CONFIRMED payment being demoted to ERROR by a duplicate
+        request holding a stale instance). Locking the row serializes the
+        two handlers: the second one blocks until the first commits and
+        sees the fresh state.
+        """
+        token = "550e8400-e29b-41d4-a716-446655440000"
+        payment = Mock(variant="dummy")
+        locked_queryset = MagicMock(spec=QuerySet)
+        locked_queryset.get.return_value = payment
+        payment_model = Mock()
+        payment_model.objects.select_for_update.return_value = locked_queryset
+        mock_get_model.return_value = payment_model
+        provider = Mock()
+        provider.process_data.return_value = HttpResponse("ok")
+        mock_factory.return_value = provider
+
+        response = self.client.post(f"/payments/process/{token}/")
+
+        assert response.status_code == 200
+        payment_model.objects.select_for_update.assert_called_once_with()
+        locked_queryset.get.assert_called_once_with(token=uuid.UUID(token))
+        provider.process_data.assert_called_once()
+        assert provider.process_data.call_args[0][0] is payment

--- a/payments/urls.py
+++ b/payments/urls.py
@@ -40,7 +40,12 @@ def process_data(
     and converted to JSON error responses for webhook systems.
     """
     Payment = get_payment_model()
-    payment = get_object_or_404(Payment, token=token)
+    # Lock the payment row for the duration of the (already atomic) request:
+    # concurrent callbacks for the same payment - e.g. the provider's
+    # asynchronous webhook and the customer's browser POSTing to this URL -
+    # otherwise interleave on instances loaded before each other's commit,
+    # and the loser overwrites the winner's state with stale data.
+    payment = get_object_or_404(Payment.objects.select_for_update(), token=token)
     if not provider:
         try:
             provider = provider_factory(payment.variant, payment)


### PR DESCRIPTION
## The problem

`process_data` runs inside `@atomic`, but fetches the payment without a row
lock. Providers commonly deliver their asynchronous webhook to the same
process URL that the customer's browser POSTs to (widget/wallet token
submissions, 3DS returns, refreshes). When two such requests overlap for the
same payment, each handler works on an instance loaded before the other's
commit — and the loser overwrites the winner's state with stale data.

This is not theoretical. Observed twice in production (PayU provider,
2026-07-27/28), reconstructed from django-simple-history:

| time (UTC) | actor | event |
|---|---|---|
| 00:42:15 | browser request B | `create_order`, gets 3DS redirect |
| 00:42:16.9 | PayU | frictionless 3DS approval, webhook fires |
| 00:42:17.2 | webhook request A | payment → CONFIRMED, order completed, money captured |
| 00:42:19.5 | request B (stale instance, loaded ≤00:42:16) | duplicate `create_order` rejected (single-use token) → `change_status(ERROR)` |

Result: a paid, captured payment recorded as `error`, and its completed
order cancelled by the host app's `status_changed` handler. Provider-level
in-memory status guards cannot close this: the instance they check is
exactly what is stale.

## The fix

```python
payment = get_object_or_404(Payment.objects.select_for_update(), token=token)
```

With the row locked, the second callback blocks at fetch until the first
commits, then observes the fresh state. Notes:

- **No new lock duration.** The transaction already spans the whole handler
  (`@atomic` was there before); the lock lives exactly as long.
- **Contention is per payment.** Only concurrent requests for the *same*
  payment serialize; cross-payment traffic is unaffected.
- **`static_callback` inherits the fix** — it delegates to `process_data`.
- **SQLite unchanged** — Django documents `select_for_update()` as a no-op
  on backends without `SELECT ... FOR UPDATE`.

## Tests

Written test-first: `ProcessDataLockingTestCase` asserts the locked fetch
and that the fetched payment reaches `provider.process_data`; it failed
against the previous code ("Expected 'select_for_update' to be called once.
Called 0 times."). Full suite passes. The test asserts the queryset
contract rather than racing threads because the test settings run an
in-memory SQLite database with no concrete payment model.

Related (adjacent, not duplicates): #309 discusses `change_status` save
semantics under concurrent modification; #436 (PayPal changes made in a
`status_changed` handler getting lost) matches the pattern of unserialized
concurrent handlers that this PR addresses.
