### PR TITLE
Make the callback flow reusable for secondary payment models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ releases, in reverse chronological order.
 v4.0.0
 ------
 
+- Fixed a race between concurrent callbacks for the same payment: the
+  ``process_data`` view now fetches the payment with ``select_for_update()``
+  inside its existing transaction, so e.g. a provider's asynchronous webhook
+  and the customer's browser POSTing to the same process URL are serialized
+  instead of interleaving on stale instances (which could overwrite a
+  captured, CONFIRMED payment's state with a stale failure). On databases
+  without ``SELECT ... FOR UPDATE`` support (such as SQLite) the behavior is
+  unchanged.
 - **Breaking**: Webhook error responses in ``static_callback`` endpoint now
   return JSON instead of raising ``Http404``. Error responses include
   ``variant`` and ``error_code`` fields for easier debugging. This helps

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ releases, in reverse chronological order.
 v4.0.0
 ------
 
+- ``process_data`` accepts a ``payment_model`` argument, and its two steps are
+  exposed as ``get_payment_or_404(token, payment_model=None)`` and
+  ``process_payment_data(payment, request, provider=None)``. Projects that
+  charge through more than one payment model (``PAYMENT_MODEL`` names only
+  one) can now route or compose the canonical callback flow instead of
+  copying the view - copies silently miss later fixes made here, such as the
+  row locking below.
 - Fixed a race between concurrent callbacks for the same payment: the
   ``process_data`` view now fetches the payment with ``select_for_update()``
   inside its existing transaction, so e.g. a provider's asynchronous webhook

--- a/docs/payment-model.rst
+++ b/docs/payment-model.rst
@@ -135,3 +135,51 @@ the payment model for an application. This is done by adding a variable to the
 
   # A dotted path to the Payment class.
   PAYMENT_MODEL = 'mypaymentapp.models.Payment'
+
+Using more than one payment model
+---------------------------------
+
+``PAYMENT_MODEL`` names a single model, but a project may charge through
+several (e.g. subscriptions and marketplace orders with separate models and
+separate callback URLs). Rather than reimplementing the callback view for the
+additional models, route :func:`payments.urls.process_data` for them with a
+``payment_model`` keyword argument:
+
+.. code-block:: python
+
+  from payments.urls import process_data
+
+  from .models import MarketplacePayment
+
+  urlpatterns = [
+      path(
+          "marketplace/process/<uuid:token>/",
+          process_data,
+          {"payment_model": MarketplacePayment},
+          name="process_marketplace_payment",
+      ),
+  ]
+
+A view that needs custom logic around the provider call can compose the two
+steps instead, keeping the locked fetch that makes concurrent callbacks safe:
+
+.. code-block:: python
+
+  from django.db.transaction import atomic
+  from django.views.decorators.csrf import csrf_exempt
+
+  from payments.urls import get_payment_or_404
+  from payments.urls import process_payment_data
+
+  @csrf_exempt
+  @atomic
+  def process_marketplace_payment(request, token):
+      payment = get_payment_or_404(token, MarketplacePayment)
+      if payment.order.is_cancelled:
+          return redirect("order-cancelled")
+      return process_payment_data(payment, request)
+
+Both helpers must run inside a transaction - ``get_payment_or_404`` locks the
+payment row so that a provider's asynchronous webhook and the customer's
+browser hitting the same URL are serialized instead of overwriting each
+other's state.

--- a/payments/test_urls.py
+++ b/payments/test_urls.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import uuid
+from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
+from django.db.models import QuerySet
+from django.http import HttpResponse
 from django.test import TestCase
 
 from payments import PaymentError
@@ -82,3 +86,42 @@ class StaticCallbackTestCase(TestCase):
         assert data["variant"] == "dummy"
         # Token should not be exposed in error response for security
         assert "token" not in data
+
+
+class ProcessDataLockingTestCase(TestCase):
+    """Concurrent callbacks for one payment must be serialized."""
+
+    @patch("payments.urls.provider_factory")
+    @patch("payments.urls.get_payment_model")
+    def test_process_data_locks_the_payment_row(self, mock_get_model, mock_factory):
+        """The payment must be fetched with select_for_update().
+
+        ``process_data`` already runs inside ``@atomic``, but it used to
+        fetch the payment without a row lock. Two concurrent callbacks for
+        the same payment - typically the provider's asynchronous webhook
+        and the customer's browser POSTing to the same process URL - then
+        interleave on instances loaded before each other's commit, and the
+        loser overwrites the winner's state (observed in production as a
+        captured, CONFIRMED payment being demoted to ERROR by a duplicate
+        request holding a stale instance). Locking the row serializes the
+        two handlers: the second one blocks until the first commits and
+        sees the fresh state.
+        """
+        token = "550e8400-e29b-41d4-a716-446655440000"
+        payment = Mock(variant="dummy")
+        locked_queryset = MagicMock(spec=QuerySet)
+        locked_queryset.get.return_value = payment
+        payment_model = Mock()
+        payment_model.objects.select_for_update.return_value = locked_queryset
+        mock_get_model.return_value = payment_model
+        provider = Mock()
+        provider.process_data.return_value = HttpResponse("ok")
+        mock_factory.return_value = provider
+
+        response = self.client.post(f"/payments/process/{token}/")
+
+        assert response.status_code == 200
+        payment_model.objects.select_for_update.assert_called_once_with()
+        locked_queryset.get.assert_called_once_with(token=uuid.UUID(token))
+        provider.process_data.assert_called_once()
+        assert provider.process_data.call_args[0][0] is payment

--- a/payments/test_urls.py
+++ b/payments/test_urls.py
@@ -7,11 +7,16 @@ from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import pytest
 from django.db.models import QuerySet
+from django.http import Http404
 from django.http import HttpResponse
 from django.test import TestCase
 
 from payments import PaymentError
+from payments.urls import get_payment_or_404
+from payments.urls import process_data
+from payments.urls import process_payment_data
 
 
 class StaticCallbackTestCase(TestCase):
@@ -112,7 +117,7 @@ class ProcessDataLockingTestCase(TestCase):
         locked_queryset = MagicMock(spec=QuerySet)
         locked_queryset.get.return_value = payment
         payment_model = Mock()
-        payment_model.objects.select_for_update.return_value = locked_queryset
+        payment_model._default_manager.select_for_update.return_value = locked_queryset
         mock_get_model.return_value = payment_model
         provider = Mock()
         provider.process_data.return_value = HttpResponse("ok")
@@ -121,7 +126,113 @@ class ProcessDataLockingTestCase(TestCase):
         response = self.client.post(f"/payments/process/{token}/")
 
         assert response.status_code == 200
-        payment_model.objects.select_for_update.assert_called_once_with()
+        payment_model._default_manager.select_for_update.assert_called_once_with()
         locked_queryset.get.assert_called_once_with(token=uuid.UUID(token))
         provider.process_data.assert_called_once()
+        assert provider.process_data.call_args[0][0] is payment
+
+
+class MultiplePaymentModelsTestCase(TestCase):
+    """The callback flow must be reusable for secondary payment models.
+
+    ``PAYMENT_MODEL`` names a single model, so a project that also charges
+    e.g. subscriptions or marketplace orders through their own payment
+    models has to reimplement this view. Copies drift: they miss fixes
+    made here later (the row locking above is a real example - copies that
+    predate it stayed vulnerable). Exposing the two steps and letting the
+    view take an explicit model keeps such projects on this code path.
+    """
+
+    @staticmethod
+    def _locked_model(payment):
+        locked_queryset = MagicMock(spec=QuerySet)
+        locked_queryset.get.return_value = payment
+        payment_model = Mock()
+        payment_model._default_manager.select_for_update.return_value = locked_queryset
+        return payment_model, locked_queryset
+
+    @patch("payments.urls.get_payment_model")
+    def test_get_payment_or_404_locks_the_default_model(self, mock_get_model):
+        """Without an explicit model the configured one is used, locked."""
+        payment = Mock(variant="dummy")
+        payment_model, locked_queryset = self._locked_model(payment)
+        mock_get_model.return_value = payment_model
+        token = "550e8400-e29b-41d4-a716-446655440000"
+
+        assert get_payment_or_404(token) is payment
+
+        payment_model._default_manager.select_for_update.assert_called_once_with()
+        locked_queryset.get.assert_called_once_with(token=token)
+
+    @patch("payments.urls.get_payment_model")
+    def test_get_payment_or_404_locks_an_explicit_model(self, mock_get_model):
+        """An explicit model is used instead of the configured one."""
+        payment = Mock(variant="dummy")
+        payment_model, locked_queryset = self._locked_model(payment)
+        token = "550e8400-e29b-41d4-a716-446655440000"
+
+        assert get_payment_or_404(token, payment_model=payment_model) is payment
+
+        mock_get_model.assert_not_called()
+        payment_model._default_manager.select_for_update.assert_called_once_with()
+        locked_queryset.get.assert_called_once_with(token=token)
+
+    @patch("payments.urls.provider_factory")
+    def test_process_payment_data_resolves_the_provider(self, mock_factory):
+        """Without an explicit provider one is built from the variant."""
+        payment = Mock(variant="dummy")
+        provider = Mock()
+        provider.process_data.return_value = HttpResponse("ok")
+        mock_factory.return_value = provider
+        request = Mock()
+
+        response = process_payment_data(payment, request)
+
+        assert response.status_code == 200
+        mock_factory.assert_called_once_with("dummy", payment)
+        provider.process_data.assert_called_once_with(payment, request)
+
+    @patch("payments.urls.provider_factory")
+    def test_process_payment_data_raises_404_for_unknown_variant(self, mock_factory):
+        """An unconfigured variant is a 404, as in the view."""
+        mock_factory.side_effect = ValueError("no such variant")
+
+        with pytest.raises(Http404):
+            process_payment_data(Mock(variant="nope"), Mock())
+
+    @patch("payments.urls.provider_factory")
+    def test_process_payment_data_uses_the_given_provider(self, mock_factory):
+        """An explicit provider skips the factory (static_callback path)."""
+        payment = Mock(variant="dummy")
+        provider = Mock()
+        provider.process_data.return_value = HttpResponse("ok")
+
+        process_payment_data(payment, Mock(), provider=provider)
+
+        mock_factory.assert_not_called()
+        provider.process_data.assert_called_once()
+
+    @patch("payments.urls.provider_factory")
+    @patch("payments.urls.get_payment_model")
+    def test_process_data_accepts_an_explicit_payment_model(
+        self, mock_get_model, mock_factory
+    ):
+        """The view can be routed for a secondary payment model.
+
+        Projects can wire ``process_data`` in their own URLconf with a
+        ``payment_model`` kwarg instead of copying the whole view.
+        """
+        payment = Mock(variant="dummy")
+        payment_model, locked_queryset = self._locked_model(payment)
+        provider = Mock()
+        provider.process_data.return_value = HttpResponse("ok")
+        mock_factory.return_value = provider
+        token = "550e8400-e29b-41d4-a716-446655440000"
+
+        response = process_data(Mock(), token, payment_model=payment_model)
+
+        assert response.status_code == 200
+        mock_get_model.assert_not_called()
+        payment_model._default_manager.select_for_update.assert_called_once_with()
+        locked_queryset.get.assert_called_once_with(token=token)
         assert provider.process_data.call_args[0][0] is payment

--- a/payments/urls.py
+++ b/payments/urls.py
@@ -22,7 +22,48 @@ from . import get_payment_model
 from .core import provider_factory
 
 if TYPE_CHECKING:
+    from django.db.models import Model
+
     from .core import BasicProvider
+
+
+def get_payment_or_404(token: str, payment_model: type[Model] | None = None):
+    """Fetch a payment by its token, locking the row.
+
+    Locking serializes concurrent callbacks for the same payment - e.g. the
+    provider's asynchronous webhook and the customer's browser POSTing to the
+    process URL. Without it the handlers interleave on instances loaded before
+    each other's commit and the loser overwrites the winner's state with stale
+    data. Must be called inside a transaction.
+
+    ``payment_model`` defaults to the configured :ref:`PAYMENT_MODEL`. Projects
+    that charge through more than one payment model can pass theirs to reuse
+    this flow instead of reimplementing it.
+    """
+    if payment_model is None:
+        payment_model = get_payment_model()
+    # _default_manager (rather than .objects) is what get_object_or_404 uses
+    # when handed a model class, so locking does not change which manager a
+    # project's payment model is looked up through.
+    queryset = payment_model._default_manager.select_for_update()
+    return get_object_or_404(queryset, token=token)
+
+
+def process_payment_data(
+    payment,
+    request: HttpRequest,
+    provider: BasicProvider | None = None,
+) -> HttpResponse:
+    """Hand callback data for an already fetched payment to its provider.
+
+    Raises Http404 if the payment's variant is not configured.
+    """
+    if provider is None:
+        try:
+            provider = provider_factory(payment.variant, payment)
+        except ValueError as e:
+            raise Http404("No such payment") from e
+    return provider.process_data(payment, request)
 
 
 @csrf_exempt
@@ -31,6 +72,7 @@ def process_data(
     request: HttpRequest,
     token: str,
     provider: BasicProvider | None = None,
+    payment_model: type[Model] | None = None,
 ) -> HttpResponse:
     """
     Calls process_data of an appropriate provider.
@@ -38,20 +80,13 @@ def process_data(
     Raises Http404 if variant does not exist.
     Note: When called via static_callback, Http404 exceptions are caught
     and converted to JSON error responses for webhook systems.
+
+    ``payment_model`` overrides the configured :ref:`PAYMENT_MODEL`, so a
+    project with a secondary payment model can route this view for it from
+    its own URLconf rather than copying the view.
     """
-    Payment = get_payment_model()
-    # Lock the payment row for the duration of the (already atomic) request:
-    # concurrent callbacks for the same payment - e.g. the provider's
-    # asynchronous webhook and the customer's browser POSTing to this URL -
-    # otherwise interleave on instances loaded before each other's commit,
-    # and the loser overwrites the winner's state with stale data.
-    payment = get_object_or_404(Payment.objects.select_for_update(), token=token)
-    if not provider:
-        try:
-            provider = provider_factory(payment.variant, payment)
-        except ValueError as e:
-            raise Http404("No such payment") from e
-    return provider.process_data(payment, request)
+    payment = get_payment_or_404(token, payment_model)
+    return process_payment_data(payment, request, provider)
 
 
 @csrf_exempt

--- a/payments/urls.py
+++ b/payments/urls.py
@@ -40,7 +40,12 @@ def process_data(
     and converted to JSON error responses for webhook systems.
     """
     Payment = get_payment_model()
-    payment = get_object_or_404(Payment, token=token)
+    # Lock the payment row for the duration of the (already atomic) request:
+    # concurrent callbacks for the same payment - e.g. the provider's
+    # asynchronous webhook and the customer's browser POSTing to this URL -
+    # otherwise interleave on instances loaded before each other's commit,
+    # and the loser overwrites the winner's state with stale data.
+    payment = get_object_or_404(Payment.objects.select_for_update(), token=token)
     if not provider:
         try:
             provider = provider_factory(payment.variant, payment)


### PR DESCRIPTION
> Depends on #PR1 — this branch contains that commit until it merges. Please review it after (or alongside) that one.

## The problem

`PAYMENT_MODEL` names a single model, but projects commonly charge through several — subscriptions, marketplace orders, card verification — each with its own model and its own callback URL. There is currently no way to reuse `process_data` for the additional ones, so those projects copy the view into their codebase.

Copies drift, and the drift is invisible until it costs something. Concretely: a project of ours carries four such copies. When `process_data` learned to lock the payment row (#PR1), none of the copies did, and all four kept the race that had already demoted a captured payment to `error` in production. Any future fix here has the same problem.

## The change

Split the view into the two steps it always was, and let it take the model:

```python
def get_payment_or_404(token, payment_model=None):      # the locked fetch
def process_payment_data(payment, request, provider=None):  # the dispatch
def process_data(request, token, provider=None, payment_model=None):
```

`process_data`'s behavior is unchanged when `payment_model` is not passed.

- A project whose extra model needs no custom logic routes the real view and inherits later fixes automatically:

  ```python
  path("marketplace/process/<uuid:token>/", process_data,
       {"payment_model": MarketplacePayment}, name="process_marketplace_payment"),
  ```

- One that needs logic around the provider call composes the two helpers and still gets the locked fetch.

Both are documented under *Using more than one payment model* in `docs/payment-model.rst`.

Two deliberate choices:

- **`payment_model`, not a `queryset` argument.** A queryset parameter would let callers pass an unlocked or pre-filtered one and silently lose the serialization the fetch exists to provide.
- **`_default_manager` instead of `.objects`.** That is what `get_object_or_404` uses when handed a model class, so adding the lock does not change which manager a project's payment model is read through. (It also types correctly — `type[Model].objects` does not.)

## Tests

Written test-first; the new tests fail without this change. They cover the default and explicit model paths, provider resolution and its `Http404`, an explicitly passed provider, and the view with an explicit model. Full suite passes; `ruff` and `mypy` clean.
